### PR TITLE
calc/apply beyond taxgains, vanilla 2

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -45,7 +45,7 @@ def FilingStatus_calc(MARS):
 
 
 def FilingStatus_apply(MARS, _sep):
-    for i in xrange(len(MARS)):
+    for i in range(len(MARS)):
         _sep[i] = FilingStatus_calc(MARS[i])
 
     return _sep
@@ -77,7 +77,7 @@ def Adj_calc(e35300_0, e35600_0, e35910_0, e03150, e03210, e03600, e03260,
 def Adj_apply(_feided, c02900, e35300_0, e35600_0, e35910_0, e03150, e03210,
     e03600, e03260, e03270, e03300, e03400, e03500, e03280, e03900, e04000,
     e03700, e03220, e03230, e03240, e03290):
-    for i in xrange(len(c02900)):
+    for i in range(len(c02900)):
         (_feided[i], c02900[i]) = Adj_calc(e35300_0[i],
             e35600_0[i], e35910_0[i], e03150[i], e03210[i], e03600[i], e03260[i],
             e03270[i], e03300[i], e03400[i], e03500[i], e03280[i], e03900[i],
@@ -126,7 +126,7 @@ def CapGains_apply(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3, _sep,
     e01700, e02000, e02100, e02300, e02400, e02600, e02610, e02800, e02540,
     c02900, e03210, e03220, e03230, e03240, e02615, f2555):
 
-    for i in xrange(len(e23250)):
+    for i in range(len(e23250)):
         (c23650[i], c01000[i], c02700[i], _ymod1[i],
             _ymod2[i], _ymod3[i], _ymod[i]) = CapGains_calc(c23650[i], c01000[i],
             c02700[i], _ymod[i], _ymod1[i], _ymod2[i], _ymod3[i], _sep[i],

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -38,17 +38,29 @@ def calculator(data, mods="", **kwargs):
     return calc
 
 
-@vectorize('int64(int64)', nopython=True)
-def filing_status_sep(MARS):
+@jit(nopython=True)
+def FilingStatus_calc(MARS):
     if MARS == 3 or MARS == 6:
         return 2
     return 1
 
 
+@jit(nopython=True)
+def FilingStatus_apply(MARS, _sep):
+    for i in xrange(len(MARS)):
+        _sep[i] = FilingStatus_calc(MARS[i])
+
+    return _sep
+
+
 def FilingStatus(p):
     # Filing based on marital status
-    # TODO: get rid of _txp in tests
-    p._sep = filing_status_sep(MARS)
+    # IK: I wonder if it makes sense to compute _sep as part of reading in
+    # the PUF file since a) the computation is simple and b) it seems to me
+    # strange to consider it as a "parameter" when it depends solely on the
+    # PUF
+    global _sep
+    p._sep = FilingStatus_apply(MARS, _sep)
     return DataFrame(data=p._sep,
                      columns=['_sep', ])
 

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -98,7 +98,8 @@ def CapGains(p):
                      columns=['c23650', 'c01000', 'c02700', '_ymod1', '_ymod2',
                                '_ymod3', '_ymod'])
 
-@jit('void(float64[:], int64[:], int64[:], float64[:], int64[:], int64[:], int64[:], float64[:])', nopython=True)
+# @jit('void(float64[:], int64[:], int64[:], float64[:], int64[:], int64[:], int64[:], float64[:])', nopython=True)
+@jit(nopython=True)
 def SSBenefits_c02500(SSIND, MARS, e02500, _ymod, e02400, _ssb50, _ssb85, c02500):
 
     for i in range(0, MARS.shape[0]):
@@ -310,7 +311,8 @@ def EI_FICA(p):
     return DataFrame(data=np.column_stack(outputs), columns=header), _earned
 
 
-@jit("void(float64[:], int64[:], int64[:], int64, int64[:,:], float64[:])", nopython=True)
+# @jit("void(float64[:], int64[:], int64[:], int64, int64[:,:], float64[:])", nopython=True)
+@jit(nopython=True)
 def StdDed_c15100(_earned, DSI, FLPDYR, default_yr, _stded, c15100):
     for i in range(0, FLPDYR.shape[0]):
         if DSI[i] == 1:
@@ -319,7 +321,8 @@ def StdDed_c15100(_earned, DSI, FLPDYR, default_yr, _stded, c15100):
             c15100[i] = 0
 
 
-@jit("void(int64[:], int64[:], float64[:], int64[:], int64[:], float64[:], int64[:], int64, int64[:,:], float64[:])", nopython=True)
+# @jit("void(int64[:], int64[:], float64[:], int64[:], int64[:], float64[:], int64[:], int64, int64[:,:], float64[:])", nopython=True)
+@jit(nopython=True)
 def StdDed_c04100(DSI, MARS, c15100, FLPDYR, MIdR, _earned, _compitem, default_yr, _stded, c04100):
     for i in range(0, MARS.shape[0]):
         if (DSI[i] == 1):
@@ -338,7 +341,8 @@ def StdDed_txpyers(MARS):
         return 1
 
 
-@jit("void(float64[:], int64[:], float64[:], float64[:], float64[:], int64[:], int64, int64[:], int64[:,:])", nopython=True)
+# @jit("void(float64[:], int64[:], float64[:], float64[:], float64[:], int64[:], int64, int64[:], int64[:,:])", nopython=True)
+@jit(nopython=True)
 def StdDed_c04200(c04200, MARS, e04200, _numextra, _exact, _txpyers, DEFAULT_YR, FLPDYR, _aged):
     for i in range(MARS.shape[0]):
         if _exact[i] == 1 and MARS[i] == 3 or MARS[i] == 5:
@@ -698,7 +702,7 @@ def TaxGains0_jit(e00650, c04800, e01000, c23650, e23250, e01100, e58990, e58980
 
 
 @jit(nopython=True)
-def apply_TaxGains0(e00650, c04800, e01000, c23650, e23250, e01100, e58990, 
+def apply_TaxGains0(e00650, c04800, e01000, c23650, e23250, e01100, e58990,
     e58980, e24515, e24518, _brk2, FLPDYR, DEFAULT_YR, MARS, _taxinc, _brk6,  _xyztax, _feided, _feitax, _cmp,
     e59410, e59420, e59440, e59470, e59400, e83200_0, e10105, e74400,
     c00650, _hasgain, _dwks5, c24505, c24510, _dwks9, c24516, _dwks12,
@@ -1234,7 +1238,7 @@ def ChildTaxCredit(p):
 
 
 # def HopeCredit():
-    # W/o congressional action, Hope Credit will replace 
+    # W/o congressional action, Hope Credit will replace
     # American opportunities credit in 2018. NEED TO ADD LOGIC!!!
 
 
@@ -1576,23 +1580,24 @@ def Taxer(inc_in, inc_out, MARS, p):
 
     return inc_out
 
-@jit('float64(float64, int64, int64, int64)', nopython = True)
+# @jit('float64(float64, int64, int64, int64)', nopython = True)
+@jit(nopython=True)
 def Taxer_i(inc_in, MARS, FLPDYR, DEFAULT_YR):
     ## note still should pass in all globals being used, including _rt1-_rt7 and _brk1-_brk6
 
-    # low = 0 
+    # low = 0
     # med = 0
 
     # if inc_in < 3000:
-    #     low = 1 
+    #     low = 1
 
     # elif inc_in >=3000 and inc_in < 100000:
-    #     med = 1 
+    #     med = 1
 
     # _a1 = inc_in * 0.01
 
     # # if _a1 < 0:
-    # #     _a2 = math.floor(_a1) - 1 
+    # #     _a2 = math.floor(_a1) - 1
     # # else: _a2 = math.floor(_a1)
     # _a2 = math.floor(_a1)
 
@@ -1612,13 +1617,13 @@ def Taxer_i(inc_in, MARS, FLPDYR, DEFAULT_YR):
     #     _a5 = 88
     # elif med == 1 and _a4 < 50:
     #     _a5 = 25
-    # elif med == 1 and _a4 >= 50: 
+    # elif med == 1 and _a4 >= 50:
     #     _a5 = 75
     # if inc_in == 0:
     #     _a5 = 0
 
     # if low == 1 or med == 1:
-    #     _a6 = _a3 + _a5 
+    #     _a6 = _a3 + _a5
     # else: _a6 = inc_in
 
     _a6 = inc_in

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -73,16 +73,16 @@ def Adj():
                      columns=['_feided', 'c02900'])
 
 
-def CapGains(p):
-    # Capital Gains
-    global _ymod
-    global _ymod1
-    global c02700
-    global c23650
-    global c01000
+@jit(nopython=True)
+def CapGains_calc(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3, _sep, _feimax, _feided,
+    DEFAULT_YR, FLPDYR, e23250, e22250, e23660, e00200, e00300, e00400, e00600,
+    e00700, e00800, e00900, e01100, e01200, e01400, e01700, e02000, e02100,
+    e02300, e02400, e02600, e02610, e02800, e02540, c02900, e03210, e03220,
+    e03230, e03240, e02615, f2555):
+
     c23650 = e23250 + e22250 + e23660
-    c01000 = np.maximum(-3000 / p._sep, c23650)
-    c02700 = np.minimum(_feided, p._feimax[FLPDYR - p.DEFAULT_YR] * f2555)
+    c01000 = max(-3000 / _sep, c23650)
+    c02700 = min(_feided, _feimax[FLPDYR - DEFAULT_YR] * f2555)
     _ymod1 = (e00200 + e00300 + e00600
             + e00700 + e00800 + e00900
             + c01000 + e01100 + e01200
@@ -93,10 +93,48 @@ def CapGains(p):
     _ymod3 = e03210 + e03230 + e03240 + e02615
     _ymod = _ymod1 + _ymod2 + _ymod3
 
-    return DataFrame(data=np.column_stack((c23650, c01000, c02700, _ymod1,
-                                           _ymod2, _ymod3, _ymod)),
-                     columns=['c23650', 'c01000', 'c02700', '_ymod1', '_ymod2',
-                               '_ymod3', '_ymod'])
+    return (c23650, c01000, c02700, _ymod1, _ymod2, _ymod3, _ymod)
+
+
+@jit(nopython=True)
+def CapGains_apply(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3, _sep,
+    _feimax, _feided, DEFAULT_YR, FLPDYR, e23250, e22250, e23660, e00200,
+    e00300, e00400, e00600, e00700, e00800, e00900, e01100, e01200, e01400,
+    e01700, e02000, e02100, e02300, e02400, e02600, e02610, e02800, e02540,
+    c02900, e03210, e03220, e03230, e03240, e02615, f2555):
+
+    for i in xrange(len(e23250)):
+        (c23650[i], c01000[i], c02700[i], _ymod1[i],
+            _ymod2[i], _ymod3[i], _ymod[i]) = CapGains_calc(c23650[i], c01000[i],
+            c02700[i], _ymod[i], _ymod1[i], _ymod2[i], _ymod3[i], _sep[i],
+            _feimax, _feided[i], DEFAULT_YR, FLPDYR[i], e23250[i], e22250[i],
+            e23660[i], e00200[i], e00300[i], e00400[i], e00600[i], e00700[i],
+            e00800[i], e00900[i], e01100[i], e01200[i], e01400[i], e01700[i],
+            e02000[i], e02100[i], e02300[i], e02400[i], e02600[i], e02610[i],
+            e02800[i], e02540[i], c02900[i], e03210[i], e03220[i], e03230[i],
+            e03240[i], e02615[i], f2555[i])
+
+    return (c23650, c01000, c02700, _ymod1, _ymod2, _ymod3, _ymod)
+
+
+def CapGains(p):
+    # Capital Gains
+    global _ymod
+    global _ymod1
+    global _ymod2
+    global _ymod3
+    global c02700
+    global c23650
+    global c01000
+
+    outputs = CapGains_apply(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3,
+        p._sep, p._feimax, _feided, p.DEFAULT_YR, FLPDYR, e23250, e22250, e23660, e00200,
+        e00300, e00400, e00600, e00700, e00800, e00900, e01100, e01200, e01400,
+        e01700, e02000, e02100, e02300, e02400, e02600, e02610, e02800, e02540,
+        c02900, e03210, e03220, e03230, e03240, e02615, f2555)
+
+    header = ['c23650', 'c01000', 'c02700', '_ymod1', '_ymod2', '_ymod3', '_ymod']
+    return DataFrame(data=np.column_stack(outputs), columns=header)
 
 # @jit('void(float64[:], int64[:], int64[:], float64[:], int64[:], int64[:], int64[:], float64[:])', nopython=True)
 @jit(nopython=True)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -63,24 +63,39 @@ def FilingStatus(p):
                      columns=['_sep', ])
 
 
-@vectorize('float64(float64, float64, float64)', nopython=True)
-def feided_vec(e35300_0, e35600_0, e35910_0):
-    return max(e35300_0, e35600_0 + e35910_0)
+def Adj_calc(e35300_0, e35600_0, e35910_0, e03150, e03210, e03600, e03260,
+    e03270, e03300, e03400, e03500, e03280, e03900, e04000, e03700, e03220,
+    e03230, e03240, e03290):
+    _feided = max(e35300_0, e35600_0 + e35910_0)
+
+    c02900 = (e03150 + e03210 + e03600 + e03260 + e03270 + e03300 + e03400 + e03500
+        + e03280 + e03900 + e04000 + e03700 + e03220 + e03230 + e03240 + e03290)
+
+    return (_feided, c02900)
+
+
+def Adj_apply(_feided, c02900, e35300_0, e35600_0, e35910_0, e03150, e03210,
+    e03600, e03260, e03270, e03300, e03400, e03500, e03280, e03900, e04000,
+    e03700, e03220, e03230, e03240, e03290):
+    for i in xrange(len(c02900)):
+        (_feided[i], c02900[i]) = Adj_calc(e35300_0[i],
+            e35600_0[i], e35910_0[i], e03150[i], e03210[i], e03600[i], e03260[i],
+            e03270[i], e03300[i], e03400[i], e03500[i], e03280[i], e03900[i],
+            e04000[i], e03700[i], e03220[i], e03230[i], e03240[i], e03290[i])
+
+    return (_feided, c02900)
 
 
 def Adj():
     # Adjustments
     global _feided, c02900
-    _feided = feided_vec(e35300_0, e35600_0, e35910_0)  # Form 2555
 
-    c02900 = (e03150 + e03210 + e03600 + e03260 + e03270 + e03300
-              + e03400 + e03500 + e03280 + e03900 + e04000 + e03700
-              + e03220 + e03230
-              + e03240
-              + e03290)
+    outputs = Adj_apply(_feided, c02900, e35300_0, e35600_0, e35910_0, e03150,
+        e03210, e03600, e03260, e03270, e03300, e03400, e03500, e03280, e03900,
+        e04000, e03700, e03220, e03230, e03240, e03290)
 
-    return DataFrame(data=np.column_stack((_feided, c02900)),
-                     columns=['_feided', 'c02900'])
+    return DataFrame(data=np.column_stack(outputs),
+        columns=['_feided', 'c02900'])
 
 
 def CapGains_calc(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3, _sep, _feimax, _feided,

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -38,14 +38,12 @@ def calculator(data, mods="", **kwargs):
     return calc
 
 
-@jit(nopython=True)
 def FilingStatus_calc(MARS):
     if MARS == 3 or MARS == 6:
         return 2
     return 1
 
 
-@jit(nopython=True)
 def FilingStatus_apply(MARS, _sep):
     for i in xrange(len(MARS)):
         _sep[i] = FilingStatus_calc(MARS[i])
@@ -85,7 +83,6 @@ def Adj():
                      columns=['_feided', 'c02900'])
 
 
-@jit(nopython=True)
 def CapGains_calc(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3, _sep, _feimax, _feided,
     DEFAULT_YR, FLPDYR, e23250, e22250, e23660, e00200, e00300, e00400, e00600,
     e00700, e00800, e00900, e01100, e01200, e01400, e01700, e02000, e02100,
@@ -108,7 +105,6 @@ def CapGains_calc(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3, _sep, _
     return (c23650, c01000, c02700, _ymod1, _ymod2, _ymod3, _ymod)
 
 
-@jit(nopython=True)
 def CapGains_apply(c23650, c01000, c02700, _ymod, _ymod1, _ymod2, _ymod3, _sep,
     _feimax, _feided, DEFAULT_YR, FLPDYR, e23250, e22250, e23660, e00200,
     e00300, e00400, e00600, e00700, e00800, e00900, e01100, e01200, e01400,
@@ -149,7 +145,6 @@ def CapGains(p):
     return DataFrame(data=np.column_stack(outputs), columns=header)
 
 # @jit('void(float64[:], int64[:], int64[:], float64[:], int64[:], int64[:], int64[:], float64[:])', nopython=True)
-@jit(nopython=True)
 def SSBenefits_c02500(SSIND, MARS, e02500, _ymod, e02400, _ssb50, _ssb85, c02500):
 
     for i in range(0, MARS.shape[0]):
@@ -213,7 +208,6 @@ def AGI(p):
 
 
 
-@jit(nopython=True)
 def ItemDed_calc(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
                  e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
                  e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
@@ -289,7 +283,6 @@ def ItemDed_calc(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900
             _phase2_i, _nonlimited, _limitratio, c04470, c21040)
 
 
-@jit(nopython=True)
 def ItemDed_apply(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
             e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
             e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
@@ -362,7 +355,6 @@ def EI_FICA(p):
 
 
 # @jit("void(float64[:], int64[:], int64[:], int64, int64[:,:], float64[:])", nopython=True)
-@jit(nopython=True)
 def StdDed_c15100(_earned, DSI, FLPDYR, default_yr, _stded, c15100):
     for i in range(0, FLPDYR.shape[0]):
         if DSI[i] == 1:
@@ -372,7 +364,6 @@ def StdDed_c15100(_earned, DSI, FLPDYR, default_yr, _stded, c15100):
 
 
 # @jit("void(int64[:], int64[:], float64[:], int64[:], int64[:], float64[:], int64[:], int64, int64[:,:], float64[:])", nopython=True)
-@jit(nopython=True)
 def StdDed_c04100(DSI, MARS, c15100, FLPDYR, MIdR, _earned, _compitem, default_yr, _stded, c04100):
     for i in range(0, MARS.shape[0]):
         if (DSI[i] == 1):
@@ -392,7 +383,6 @@ def StdDed_txpyers(MARS):
 
 
 # @jit("void(float64[:], int64[:], float64[:], float64[:], float64[:], int64[:], int64, int64[:], int64[:,:])", nopython=True)
-@jit(nopython=True)
 def StdDed_c04200(c04200, MARS, e04200, _numextra, _exact, _txpyers, DEFAULT_YR, FLPDYR, _aged):
     for i in range(MARS.shape[0]):
         if _exact[i] == 1 and MARS[i] == 3 or MARS[i] == 5:

--- a/taxcalc/puf.py
+++ b/taxcalc/puf.py
@@ -474,3 +474,9 @@ def set_input_data(calc):
     calc._nonlimited = np.zeros(dim)
     calc._phase2_i = np.zeros(dim)
     calc._limitratio = np.zeros(dim)
+
+    """
+    Introduced in CapGains()
+    """
+    calc._ymod2 = np.zeros(dim)
+    calc._ymod3 = np.zeros(dim)


### PR DESCRIPTION
I'm terribly sorry for the delay with this. I'll be adding more commits throughout the day.
For some reason my `py.test` would report errors unless I tweaked the code a bit (see comments). I did so in order to have some sort of working test to compare my refactoring to. We should be able to add these jit statements back if we need them to later.

That being said, turns out the Travis CI build seems to have failed, complaining about `xrange`. I'm not sure why the tests on my machine have completed fine though. @talumbau, @jlyons871 thoughts?