### PR TITLE
Attributes on Calc pass to Parameters/PUF

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -34,22 +34,45 @@ def calculator(parameters, puf, mods="", **kwargs):
 class Calculator(object):
 
     def __init__(self, parameters, puf):
-        self.parameters = parameters
-        self.puf = puf
+        self._parameters = parameters
+        self._puf = puf
         assert puf.current_year == parameters.current_year
 
-    def __getattr__(self, val):
+    @property
+    def parameters(self):
+        return self._parameters
 
-        if val in self.__dict__:
-            return self.__dict__[val]
+    @property
+    def puf(self):
+        return self._puf
+
+    def __getattr__(self, name):
+        """
+        Only allowed attributes on a Calculator are 'parameters' and 'puf'
+        """
+
+        if hasattr(self.parameters, name):
+            return getattr(self.parameters, name)
+        elif hasattr(self.puf, name):
+            return getattr(self.puf, name)
         else:
-            try:
-                return getattr(self.parameters, val)
-            except AttributeError:
-                try:
-                    return getattr(self.puf, val)
-                except AttributeError:
-                    raise
+            raise AttributeError(name + " not found")
+
+    def __setattr__(self, name, val):
+        """
+        Only allowed attributes on a Calculator are 'parameters' and 'puf'
+        """
+
+        if name == "_parameters" or name == "_puf":
+            self.__dict__[name] = val
+            return
+
+        if hasattr(self.parameters, name):
+            return setattr(self.parameters, name, val)
+        elif hasattr(self.puf, name):
+            return setattr(self.puf, name, val)
+        else:
+            self.__setattr__(name, val)
 
 
     def calc_all(self):

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -3,7 +3,9 @@ import sys
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, "../../"))
 import numpy as np
+from numpy.testing import assert_array_equal
 import pandas as pd
+import pytest
 from numba import jit, vectorize, guvectorize
 from taxcalc import *
 
@@ -110,6 +112,25 @@ def test_Calculator_attr_access_to_params():
     assert hasattr(calc, '_almdep')
     # local attribute
     assert hasattr(calc, 'parameters')
+
+
+def test_Calculator_set_attr_passes_through():
+
+    # Create a Parameters object
+    params = Parameters(start_year=91)
+    # Create a Public Use File object
+    puf = PUF(tax_dta)
+    # Create a Calculator
+    calc = Calculator(parameters=params, puf=puf)
+
+    assert id(calc.e00200) == id(calc.puf.e00200)
+    calc.e00200 = calc.e00200 + 100
+    assert id(calc.e00200) == id(calc.puf.e00200)
+    assert_array_equal( calc.e00200, calc.puf.e00200)
+
+    with pytest.raises(AttributeError):
+        calc.foo == 14
+
 
 
 class TaxCalcError(Exception):


### PR DESCRIPTION
`parameters` and `puf` promoted to properties on a Calculator
All other attribute setting/getting on a Calculator is dispatched
to those properties