### PR TITLE
@iterate_jit takes keyword args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
   - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION pytest numpy pandas
-  - conda install -n test-environment numba networkx six
+  - conda install -n test-environment numba networkx six toolz
   - source activate test-environment
   - python setup.py install
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -10,6 +10,7 @@ requirements:
     - numpy
     - pandas
     - numba
+    - toolz
   run:
     - pytest
     - setuptools
@@ -17,6 +18,7 @@ requirements:
     - numpy
     - pandas
     - numba
+    - toolz
 
 about:
   home: http://www.github.com/OpenSourcePolicyCenter

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 numpy >= 1.7
 numba
 six
+toolz

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -5,6 +5,7 @@ from numba import jit, vectorize, guvectorize
 from functools import wraps
 from six import StringIO
 import ast
+import toolz
 
 
 class GetReturnNode(ast.NodeVisitor):
@@ -116,7 +117,8 @@ def create_apply_function_string(sigout, sigin, parameters):
     return s.getvalue()
 
 
-def create_toplevel_function_string(args_out, args_in, pm_or_pf):
+def create_toplevel_function_string(args_out, args_in, pm_or_pf,
+                                    kwargs_for_func={}):
     """
     Create a string for a function of the form:
         def hl_func(x_0, x_1, x_2, ...):
@@ -130,9 +132,13 @@ def create_toplevel_function_string(args_out, args_in, pm_or_pf):
 
     Parameters
     ----------
-    sigout: iterable of the out arguments
+    args_out: iterable of the out arguments
 
-    sigin: iterable of the in arguments
+    args_in: iterable of the in arguments
+
+    pm_or_pf: iterable of strings for object that holds each arg
+
+    kwargs_for_func: dictionary of keyword args for the function
 
     Returns
     -------
@@ -141,11 +147,22 @@ def create_toplevel_function_string(args_out, args_in, pm_or_pf):
 
     s = StringIO()
 
-    s.write("def hl_func(pm, pf):\n")
+
+    s.write("def hl_func(pm, pf")
+    
+    if kwargs_for_func:
+        kwargs = ",".join(str(k) + "=" + str(v) for k, v in
+                          kwargs_for_func.items())
+        s.write(", " + kwargs + " ")
+
+    s.write("):\n")
     s.write("    from pandas import DataFrame\n")
     s.write("    import numpy as np\n")
     s.write("    outputs = \\\n")
     outs = []
+    for arg in kwargs_for_func:
+        args_in.remove(arg)
+
     for p, attr in zip(pm_or_pf, args_out + args_in):
         outs.append(p + "." + attr + ", ")
     outs = [m_or_f + "." + arg for m_or_f, arg in zip(pm_or_pf, args_out)]
@@ -153,6 +170,8 @@ def create_toplevel_function_string(args_out, args_in, pm_or_pf):
     s.write("        " + "applied_f(")
     for p, attr in zip(pm_or_pf, args_out + args_in):
         s.write(p + "." + attr + ", ")
+    for arg in kwargs_for_func:
+        s.write(arg + ", ")
     s.write(")\n")
 
     s.write("    header = [")
@@ -196,6 +215,7 @@ def make_apply_function(func, out_args, in_args, parameters, do_jit=True,
     """
     jitted_f = jit(**kwargs)(func)
     apfunc = create_apply_function_string(out_args, in_args, parameters)
+
     func_code = compile(apfunc, "<string>", "exec")
     fakeglobals = {}
     eval(func_code, {"jitted_f": jitted_f}, fakeglobals)
@@ -251,7 +271,14 @@ def iterate_jit(parameters=None, **kwargs):
     """
     if not parameters:
         parameters = []
+
     def make_wrapper(func):
+
+        func_kws = inspect.getargspec(func).args
+        jit_kws = inspect.getargspec(jit).args + ['nopython']
+
+        kwargs_for_func = toolz.keyfilter(func_kws.__contains__, kwargs)
+        kwargs_for_jit = toolz.keyfilter(jit_kws.__contains__, kwargs)
 
         # Step 1. Wrap this function in apply_jit
         # from apply_jit
@@ -279,7 +306,8 @@ def iterate_jit(parameters=None, **kwargs):
                                                list(reversed(all_out_args)),
                                                in_args,
                                                parameters=parameters,
-                                               do_jit=True, **kwargs)
+                                               do_jit=True,
+                                               **kwargs_for_jit)
 
         def wrapper(*args, **kwargs):
             in_arrays = []
@@ -289,14 +317,18 @@ def iterate_jit(parameters=None, **kwargs):
                 if hasattr(args[0], farg):
                     in_arrays.append(getattr(args[0], farg))
                     pm_or_pf.append("pm")
-                else:
+                elif hasattr(args[1], farg):
                     in_arrays.append(getattr(args[1], farg))
                     pm_or_pf.append("pf")
+                elif not farg in kwargs_for_func:
+                    raise ValueError("Unknown arg: " + farg)
+
 
             # Create the high level function
             high_level_func = create_toplevel_function_string(all_out_args,
-                                                              in_args,
-                                                              pm_or_pf)
+                                                              list(in_args),
+                                                              pm_or_pf,
+                                                              kwargs_for_func)
             func_code = compile(high_level_func, "<string>", "exec")
             fakeglobals = {}
             eval(func_code, {"applied_f": applied_jitted_f}, fakeglobals)

--- a/taxcalc/decorators.py
+++ b/taxcalc/decorators.py
@@ -274,19 +274,17 @@ def iterate_jit(parameters=None, **kwargs):
 
     def make_wrapper(func):
 
-        func_kws = inspect.getargspec(func).args
-        jit_kws = inspect.getargspec(jit).args + ['nopython']
-
-        kwargs_for_func = toolz.keyfilter(func_kws.__contains__, kwargs)
-        kwargs_for_jit = toolz.keyfilter(jit_kws.__contains__, kwargs)
-
         # Step 1. Wrap this function in apply_jit
         # from apply_jit
 
         # Get the input arguments from the function
         in_args = inspect.getargspec(func).args
-        src = inspect.getsourcelines(func)[0]
+        jit_args = inspect.getargspec(jit).args + ['nopython']
 
+        kwargs_for_func = toolz.keyfilter(in_args.__contains__, kwargs)
+        kwargs_for_jit = toolz.keyfilter(jit_args.__contains__, kwargs)
+
+        src = inspect.getsourcelines(func)[0]
 
         # Discover the return arguments by walking
         # the AST of the function

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -99,13 +99,16 @@ def AGI(   _ymod1, c02500, c02700, e02615, c02900, e00100, e02500, XTOT,
     
     return (c02650, c00100, _agierr, _posagi, _ywossbe, _ywossbc, _prexmp, c04600)
 
-
-@jit(nopython=True)
-def ItemDed_calc(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
+@iterate_jit(parameters=["puf", "phase2", "_phase2_i"], nopython=True, puf=True)
+def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
                  e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
                  e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
-                 MARS, _sep, c00100, puf, phase2, _phase2_i):
-
+                 MARS, _sep, c00100, phase2, _phase2_i, puf):
+    """
+    WARNING: Any additional keyword args, such as 'puf=True' here, must be passed
+    to the function at the END of the argument list. If you stick the argument
+    somewhere in the middle of the signature, you will get errors.
+    """
     # Medical #
     c17750 = 0.075 * _posagi
     c17000 = max(0, e17500 - c17750)
@@ -181,55 +184,6 @@ def ItemDed_calc(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900
     return (c17750, c17000, _sit1, _sit, _statax, c18300, c37703, c20500,
             c20750, c20400, c19200, c20800, c19700, c21060, _phase2_i,
             _nonlimited, _limitratio, c04470, c21040)
-
-
-@jit(nopython=True)
-def ItemDed_apply(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
-            e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
-            e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
-            MARS, _sep, c00100, puf,
-            c17750, c17000, _sit1, _sit, _statax, c18300, c37703, c20500, c20750, c20400, c19200,
-            c20800, c19700, c21060, phase2, _phase2_i, _nonlimited, _limitratio, c04470, c21040):
-
-
-    for i in range(len(_posagi)):
-        (c17750[i], c17000[i], _sit1[i], _sit[i], _statax[i], c18300[i], c37703[i], c20500[i],
-        c20750[i], c20400[i], c19200[i], c20800[i], c19700[i], c21060[i], _phase2_i[i],
-        _nonlimited[i], _limitratio[i], c04470[i], c21040[i]
-        ) = ItemDed_calc(
-            _posagi[i], e17500[i], e18400[i], e18425[i], e18450[i], e18500[i], e18800[i], e18900[i],
-            e20500[i], e20400[i], e19200[i], e20550[i], e20600[i], e20950[i], e19500[i], e19570[i],
-            e19400[i], e19550[i], e19800[i], e20100[i], e20200[i], e20900[i], e21000[i], e21010[i],
-            MARS[i], _sep[i], c00100[i], puf, phase2, _phase2_i)
-
-
-    return (c17750, c17000, _sit1, _sit, _statax, c18300, c37703, c20500,
-                c20750, c20400, c19200, c20800, c19700, c21060, _phase2_i,
-                _nonlimited, _limitratio, c04470, c21040)
-
-
-def ItemDed(pm, rc, puf=True):
-
-    outputs = \
-        (rc.c17750, rc.c17000, rc._sit1, rc._sit, rc._statax, rc.c18300, rc.c37703,
-         rc.c20500, rc.c20750, rc.c20400, rc.c19200, rc.c20800, rc.c19700, rc.c21060,
-         rc._phase2_i, rc._nonlimited, rc._limitratio, rc.c04470, rc.c21040) = \
-            ItemDed_apply(
-                rc._posagi, rc.e17500, rc.e18400, rc.e18425, rc.e18450, rc.e18500,
-                rc.e18800, rc.e18900, rc.e20500, rc.e20400, rc.e19200, rc.e20550, rc.e20600, rc.e20950,
-                rc.e19500, rc.e19570, rc.e19400, rc.e19550, rc.e19800, rc.e20100, rc.e20200, rc.e20900,
-                rc.e21000, rc.e21010, rc.MARS, rc._sep, rc.c00100, puf,
-                rc.c17750, rc.c17000, rc._sit1, rc._sit, rc._statax, rc.c18300, rc.c37703,
-                rc.c20500, rc.c20750, rc.c20400, rc.c19200, rc.c20800, rc.c19700, rc.c21060,
-                pm.phase2, rc._phase2_i, rc._nonlimited, rc._limitratio, rc.c04470, rc.c21040)
-
-
-    header= ['c17750', 'c17000', '_sit1', '_sit', '_statax', 'c18300', 'c37703',
-             'c20500', 'c20750', 'c20400', 'c19200', 'c20800', 'c19700',
-             'c21060', '_phase2',
-             '_nonlimited', '_limitratio', 'c04470', 'c21040']
-
-    return DataFrame(data=np.column_stack(outputs), columns=header)
 
 
 @iterate_jit(parameters=["ssmax"], nopython=True)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -58,6 +58,8 @@ def run(puf=True):
     totaldf = totaldf.T.groupby(level=0).first().T
 
     exp_results = pd.read_csv(os.path.join(CUR_PATH, "../../exp_results.csv.gz"), compression='gzip')
+    # Fix-up to bad column name in expected data
+    exp_results.rename(columns=lambda x: x.replace('_phase2', '_phase2_i'), inplace=True)
     exp_set = set(exp_results.columns)
     cur_set = set(totaldf.columns)
 

--- a/taxcalc/tests/test_decorators.py
+++ b/taxcalc/tests/test_decorators.py
@@ -257,3 +257,40 @@ def test_ret_everything_iterate_jit():
     exp = DataFrame(data=[[2.0, 2.0, 2.0, 2.0]] * 5,
                     columns=["c", "d", "e", "f"])
     assert_frame_equal(ans, exp)
+
+
+@iterate_jit(parameters=['puf'], nopython=True, puf=True)
+def Magic_calc3(x, y, z, puf):
+    a = x + y
+    if (puf):
+        b = x + y + z
+    else:
+        b = 42
+    return (a, b)
+
+
+def test_function_takes_kwarg():
+    pm = Foo()
+    pf = Foo()
+    pm.a = np.ones((5,))
+    pm.b = np.ones((5,))
+    pf.x = np.ones((5,))
+    pf.y = np.ones((5,))
+    pf.z = np.ones((5,))
+    ans = Magic_calc3(pm, pf)
+    exp = DataFrame(data=[[2.0, 3.0]] * 5,
+                    columns=["a", "b"])
+    assert_frame_equal(ans, exp)
+
+def test_function_takes_kwarg_nondefault_value():
+    pm = Foo()
+    pf = Foo()
+    pm.a = np.ones((5,))
+    pm.b = np.ones((5,))
+    pf.x = np.ones((5,))
+    pf.y = np.ones((5,))
+    pf.z = np.ones((5,))
+    ans = Magic_calc3(pm, pf, puf=False)
+    exp = DataFrame(data=[[2.0, 42.0]] * 5,
+                    columns=["a", "b"])
+    assert_frame_equal(ans, exp)


### PR DESCRIPTION
@iterate_jit can now take keyword arguments. This is mostly to help deal with the `puf=True` default args we have on some functions. The proper use is to put the keywords args at the END of the function signature, and the default keyword argument (e.g. `puf=True`) in the signature for @iterate_jit. The example of ItemDed is instructive:

```
@iterate_jit(parameters=["puf", "phase2", "_phase2_i"], nopython=True, puf=True)
def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
                 e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
                 e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
                 MARS, _sep, c00100, phase2, _phase2_i, puf):
```
