### PR TITLE
add _ospctax and _refund vars

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -143,7 +143,7 @@ class Calculator(object):
         F5405(self.parameters, self.records)
         C1040(self.parameters, self.records)
         DEITC(self.parameters, self.records)
-        SOIT(self.parameters, self.records)
+        OSPC_TAX(self.parameters, self.records)
 
     def calc_all_test(self):
         all_dfs = []
@@ -174,7 +174,7 @@ class Calculator(object):
         add_df(all_dfs, F5405(self.parameters, self.records))
         add_df(all_dfs, C1040(self.parameters, self.records))
         add_df(all_dfs, DEITC(self.parameters, self.records))
-        add_df(all_dfs, SOIT(self.parameters, self.records))
+        add_df(all_dfs, OSPC_TAX(self.parameters, self.records))
         totaldf = pd.concat(all_dfs, axis=1)
         return totaldf
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1354,11 +1354,13 @@ def DEITC(c08795, c59660, c09200, c07100):
 
 
 @iterate_jit(nopython=True)
-def OSPC_TAX( c09200, c59660, c11070, c10960 , _eitc ):
+def OSPC_TAX( c09200, c59660, c11070, c10960, c11600, c10950 , _eitc, e11580,
+              e11450, e11500, e82040):
 
-    _refund = c59660 + c11070 + c10960
+    _refund = (c59660 + c11070 + c11600 + c10960 + c10950 + e11580 + e11450 +
+               e11500)
     
-    _ospctax = c09200 - _refund
+    _ospctax = c09200 - _refund - e82040
 
     c10300 = max(0, _ospctax)
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1354,32 +1354,22 @@ def DEITC(c08795, c59660, c09200, c07100):
 
 
 @iterate_jit(nopython=True)
-def SOIT(   c09200, e10000, e59680, c59700,e11070, e11550, e11580,e09710, 
-            e09720, e11581, e11582, e87900, e87905, e87681, e87682, c10950, 
-            e11451, e11452, e11601, e11602, _eitc ):
+def OSPC_TAX( c09200, c59660, c11070, c10960 , _eitc ):
 
-    # SOI Tax (Tax after non-refunded credits plus tip penalty)
-    # QUESTION, why not consolidate into one line??
-    c10300 = c09200 - e10000 - e59680 - c59700
-    c10300 = c10300 - e11070
-    c10300 = c10300 - e11550
-    c10300 = c10300 - e11580
-    c10300 = c10300 - e09710 - e09720 - e11581 - e11582
-    c10300 = c10300 - e87900 - e87905 - e87681 - e87682
-    # QUESTION 'c10300 - c10300'a typo?
-    c10300 = c10300 - c10300 - c10950 - e11451 - e11452
-    c10300 = c09200 - e09710 - e09720 - e10000 - e11601 - e11602
+    _refund = c59660 + c11070 + c10960
+    
+    _ospctax = c09200 - _refund
 
-    c10300 = max(c10300, 0.)
+    c10300 = max(0, _ospctax)
 
-    # Ignore refundable partof _eitc to obtain SOI income tax
 
+    # Ignore refundable partof _eitc
+    #TODO Remove this _eitc
     if c09200 <= _eitc:
         _eitc = c09200
 
-        c10300 = 0.
 
-    return (c10300, _eitc)
+    return (c10300, _eitc, _refund, _ospctax)
 
 
 

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -593,7 +593,7 @@ Please pass such a csv as PUF(blowup_factors='[FILENAME]').")
                         'c82940', 'c11070', 'e59660', '_othadd', 'y07100',
                         'x07100', 'c08800', 'e08795', 'x07400', 'c59680',
                         'c59720', '_comb', 'c07150', 'c10300', '_ospctax',
-                        '_refund']
+                        '_refund', 'c11600', 'e11450', 'e82040', 'e11500']
                         
                         
 

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -592,7 +592,8 @@ Please pass such a csv as PUF(blowup_factors='[FILENAME]').")
                         'c82905', 'c82910', 'c82915',  'c82920', 'c82937',
                         'c82940', 'c11070', 'e59660', '_othadd', 'y07100',
                         'x07100', 'c08800', 'e08795', 'x07400', 'c59680',
-                        'c59720', '_comb', 'c07150', 'c10300']
+                        'c59720', '_comb', 'c07150', 'c10300', '_ospctax',
+                        '_refund']
                         
                         
 

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -62,6 +62,9 @@ def run(puf=True):
     # Fix-up to bad column name in expected data
     exp_results.rename(columns=lambda x: x.replace('_phase2', '_phase2_i'), inplace=True)
     exp_set = set(exp_results.columns)
+    # Add new col names to exp_set
+    exp_set.add('_ospctax')
+    exp_set.add('_refund')
     cur_set = set(totaldf.columns)
 
     assert(exp_set == cur_set)


### PR DESCRIPTION
Incorporate changes suggested by @feenberg here https://github.com/OpenSourcePolicyCenter/Tax-Calculator/issues/95#issuecomment-71083006. Note that I add _ospctax and _refund to the set of column names in test_calculate.py https://github.com/MattHJensen/taxcalc/compare/ospc_tax?expand=1#diff-03c8c8e4581079a84e9a80e191c841a3R65

