### PR TITLE
[WIP] Recalculate tax between substitution effect and income effect in behavior() 

### DIFF
--- a/docs/Behavioral_example.ipynb
+++ b/docs/Behavioral_example.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:80ad444e86448016d74ded84b4f0fac4693d611ff830ac3f9162f2fa63967f16"
+  "signature": "sha256:aa7cac6be5527ca83ee95c3e57381cde1700080321c0bed1b43eccdb9a70e6a9"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -45,8 +45,8 @@
      "collapsed": false,
      "input": [
       "# Create a Records object for Plan X and Plan Y\n",
-      "records_x = Records(\"../puf2.csv\", \"../StageIFactors.csv\", \"../WEIGHTS.csv\")\n",
-      "records_y = Records(\"../puf2.csv\", \"../StageIFactors.csv\", \"../WEIGHTS.csv\")\n",
+      "records_x = Records(\"../puf2.csv\")\n",
+      "records_y = Records(\"../puf2.csv\")\n",
       "# Create a Parameters object for Plan X and Plan Y\n",
       "params_x = Parameters(start_year=2013)\n",
       "params_y = Parameters(start_year=2013)\n",
@@ -117,30 +117,11 @@
        "stream": "stdout",
        "text": [
         "39476697078\n",
-        "39093607156.9\n"
+        "39059892867.0\n"
        ]
       }
      ],
      "prompt_number": 4
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Now you can run the tax calculations to get your new tax liabilities with microfeedback effects incorporated. \n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "calc_y_behavioral.calc_all()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
     },
     {
      "cell_type": "code",

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -1,35 +1,10 @@
 import numpy as np
 import copy
 
-def behavior(calcX, calcY, elast_wrt_atr = 0.4, inc_effect = 0.15):
-	"""
-    Modify plan Y records to account for micro-feedback effect that arrise 
-    from moving from plan X to plan Y. 
-    """
-
-	# Calculate marginal tax rates for plan x and plan y.
-	mtrX = calcX.mtr('e00200')
-
-	mtrY = calcY.mtr('e00200')
-
-	# Calculate the percent change in after-tax rate.
-	pct_diff_atr = ((1-mtrY) - (1-mtrX))/(1-mtrX)
-
-
-	# Calculate the magnitude of the substitution and income effects. 
-	substitution_effect = (elast_wrt_atr * pct_diff_atr * 
-							(calcX.c05200))
-
-
-	income_effect = inc_effect * (calcY.c05200 - calcX.c05200)
-
+def update_income(effect, calcY):  
 	delta_inc = np.where(calcY.c00100 > 0 ,
-				substitution_effect + income_effect, 0)
+				effect, 0)
 
-	# TODO Replace c05200 with _ospctax.
-	# TODO Currently we are not recalculating tax with the substitution
-	# effect before calculating the income effect. Should we be? 
-	
 	# Attribute the behavioral effects across itemized deductions, 
 	# wages, and other income. 
 
@@ -48,16 +23,51 @@ def behavior(calcX, calcY, elast_wrt_atr = 0.4, inc_effect = 0.15):
 	delta_itemized = (delta_inc * _itemized / 
 						(calcY.c00100 + _itemized + .001))
 
-	calcY_behavior = copy.deepcopy(calcY)
+	calcY.e00200 = calcY.e00200 + delta_wages
 
-	calcY_behavior.e00200 = calcY_behavior.e00200 + delta_wages
+	calcY.e00300 = calcY.e00300 + delta_other_inc
 
-	calcY_behavior.e00300 = calcY_behavior.e00300 + delta_other_inc
-
-	calcY_behavior.e19570 = np.where(_itemized > 0, 
-							calcY_behavior.e19570 + delta_itemized, 0)
+	calcY.e19570 = np.where(_itemized > 0, 
+							calcY.e19570 + delta_itemized, 0)
 	#TODO, we should create a behavioral modification 
 	# variable instead of using e19570
 
+	calcY.calc_all()
+
+	return calcY
+
+
+def behavior(calcX, calcY, elast_wrt_atr=0.4, inc_effect=0.15, update_income=update_income):
+	"""
+    Modify plan Y records to account for micro-feedback effect that arrise 
+    from moving from plan X to plan Y. 
+    """
+
+	# Calculate marginal tax rates for plan x and plan y.
+	mtrX = calcX.mtr('e00200')
+
+	mtrY = calcY.mtr('e00200')
+
+	# Calculate the percent change in after-tax rate.
+	pct_diff_atr = ((1-mtrY) - (1-mtrX))/(1-mtrX)
+
+	calcY_behavior = copy.deepcopy(calcY)
+
+	# Calculate the magnitude of the substitution and income effects. 
+	substitution_effect = (elast_wrt_atr * pct_diff_atr * 
+							(calcX._ospctax))
+
+
+	calcY_behavior = update_income(substitution_effect, calcY_behavior)
+
+
+	income_effect = inc_effect * (calcY_behavior._ospctax - calcX._ospctax)
+
+	calcY_behavior = update_income(income_effect, calcY_behavior)
+
 	return calcY_behavior
+
+
+
+
 

--- a/taxcalc/behavior.py
+++ b/taxcalc/behavior.py
@@ -1,9 +1,9 @@
 import numpy as np
 import copy
 
-def update_income(effect, calcY):  
+def update_income(behavioral_effect, calcY):  
 	delta_inc = np.where(calcY.c00100 > 0 ,
-				effect, 0)
+				behavioral_effect, 0)
 
 	# Attribute the behavioral effects across itemized deductions, 
 	# wages, and other income. 


### PR DESCRIPTION
This fixes the issues described in https://github.com/OpenSourcePolicyCenter/Tax-Calculator/issues/116#issuecomment-75261167

I am going to send this new code to Dan for review and will drop the [WIP] tag when I hear back. 

This pr includes commits from #134 because I expect that to be merged first and wanted to see the results of our behavioral calculator with the improved mtr(). 