### PR TITLE
Read default files from .egg distribution

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -2,13 +2,14 @@ import numpy as np
 from .utils import expand_array
 import os
 import json
-
+from pkg_resources import resource_stream, Requirement
 
 class Parameters(object):
 
 
     CUR_PATH = os.path.abspath(os.path.dirname(__file__))
-    params_path = os.path.join(CUR_PATH, "params.json")
+    PARAM_FILENAME = "params.json"
+    params_path = os.path.join(CUR_PATH, PARAM_FILENAME)
 
     @classmethod
     def from_file(cls, file_name, **kwargs):
@@ -58,10 +59,18 @@ class Parameters(object):
 
 def default_data(metadata=False):
     """ Retreive of default parameters """
-    with open(Parameters.params_path) as f:
-        paramfile = json.load(f)
+    parampath = Parameters.params_path
+    if not os.path.exists(parampath):
+        path_in_egg = os.path.join("taxcalc", Parameters.PARAM_FILENAME)
+        buf = resource_stream(Requirement.parse("taxcalc"), path_in_egg)
+        _bytes = buf.read()
+        as_string = _bytes.decode("utf-8")
+        params = json.loads(as_string)
+    else:
+        with open(Parameters.params_path) as f:
+            params = json.load(f)
 
     if (metadata):
-        return paramfile
+        return params
     else:
-        return { k: v['value'] for k,v in paramfile.items()}
+        return { k: v['value'] for k,v in params.items()}

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -5,6 +5,8 @@ This file reads input csv file and saves the variables
 import pandas as pd
 import numpy as np
 import os.path
+import os
+from pkg_resources import resource_stream, Requirement
 
 class Records(object):
     """
@@ -21,8 +23,10 @@ class Records(object):
     Advancing years is done through a member function
     """
     CUR_PATH = os.path.abspath(os.path.dirname(__file__))
-    weights_path = os.path.join(CUR_PATH, "WEIGHTS.csv")
-    blowup_factors_path = os.path.join(CUR_PATH, "StageIFactors.csv")
+    WEIGHTS_FILENAME = "WEIGHTS.csv"
+    weights_path = os.path.join(CUR_PATH, WEIGHTS_FILENAME)
+    BLOWUP_FACTORS_FILENAME = "StageIFactors.csv"
+    blowup_factors_path = os.path.join(CUR_PATH, BLOWUP_FACTORS_FILENAME)
 
 
 
@@ -247,6 +251,10 @@ class Records(object):
             WT = weights 
         else: 
             try:
+                if not os.path.exists(weights):
+                    #grab weights out of EGG distribution
+                    path_in_egg = os.path.join("taxcalc", self.WEIGHTS_FILENAME)
+                    weights = resource_stream(Requirement.parse("taxcalc"), path_in_egg)
                 WT = pd.read_csv(weights)
             except IOError:
                 print("Missing a csv file with weights from the second \
@@ -263,6 +271,11 @@ PUF(weights='[FILENAME]').")
             BF = blowup_factors
         else:
             try:
+                if not os.path.exists(blowup_factors):
+                    #grab blowup factors out of EGG distribution
+                    path_in_egg = os.path.join("taxcalc", self.BLOWUP_FACTORS_FILENAME)
+                    blowup_factors = resource_stream(Requirement.parse("taxcalc"), path_in_egg)
+
                 BF = pd.read_csv(blowup_factors, index_col='YEAR')
             except IOError:
                 print("Missing a csv file with blowup factors. \

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -76,7 +76,7 @@ def test_create_tables():
 def test_weighted_count_lt_zero():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
-    diffs = grped.apply(weighted_count_lt_zero)
+    diffs = grped.apply(weighted_count_lt_zero, 'tax_diff')
     exp = Series(data=[4, 0], index=['a', 'b'])
     assert_series_equal(exp, diffs)
 
@@ -84,7 +84,7 @@ def test_weighted_count_lt_zero():
 def test_weighted_count_gt_zero():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
-    diffs = grped.apply(weighted_count_gt_zero)
+    diffs = grped.apply(weighted_count_gt_zero, 'tax_diff')
     exp = Series(data=[8, 10], index=['a', 'b'])
     assert_series_equal(exp, diffs)
  
@@ -100,7 +100,7 @@ def test_weighted_count():
 def test_weighted_mean():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
-    diffs = grped.apply(weighted_mean)
+    diffs = grped.apply(weighted_mean, 'tax_diff')
     exp = Series(data=[16.0/12.0, 26.0/10.0], index=['a', 'b'])
     assert_series_equal(exp, diffs)
  
@@ -108,7 +108,7 @@ def test_weighted_mean():
 def test_weighted_sum():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
-    diffs = grped.apply(weighted_sum)
+    diffs = grped.apply(weighted_sum, 'tax_diff')
     exp = Series(data=[16.0, 26.0], index=['a', 'b'])
     assert_series_equal(exp, diffs)
  
@@ -116,7 +116,7 @@ def test_weighted_sum():
 def test_weighted_perc_inc():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
-    diffs = grped.apply(weighted_perc_inc)
+    diffs = grped.apply(weighted_perc_inc, 'tax_diff')
     exp = Series(data=[8./12., 1.0], index=['a', 'b'])
     assert_series_equal(exp, diffs)
 
@@ -124,7 +124,7 @@ def test_weighted_perc_inc():
 def test_weighted_perc_dec():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
-    diffs = grped.apply(weighted_perc_dec)
+    diffs = grped.apply(weighted_perc_dec, 'tax_diff')
     exp = Series(data=[4./12., 0.0], index=['a', 'b'])
     assert_series_equal(exp, diffs)
 
@@ -132,7 +132,7 @@ def test_weighted_perc_dec():
 def test_weighted_share_of_total():
     df = DataFrame(data=data, columns=['tax_diff', 's006', 'label'])
     grped = df.groupby('label')
-    diffs = grped.apply(weighted_share_of_total, 42.0)
+    diffs = grped.apply(weighted_share_of_total, 'tax_diff', 42.0)
     exp = Series(data=[16.0/42., 26.0/42.0], index=['a', 'b'])
     assert_series_equal(exp, diffs)
  

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -116,36 +116,36 @@ def count_lt_zero(agg):
     return sum([1 for a in agg if a < 0])
 
 
-def weighted_count_lt_zero(agg):
-    return agg[agg['tax_diff'] < 0]['s006'].sum()
+def weighted_count_lt_zero(agg, col_name):
+    return agg[agg[col_name] < 0]['s006'].sum()
 
 
-def weighted_count_gt_zero(agg):
-    return agg[agg['tax_diff'] > 0]['s006'].sum()
+def weighted_count_gt_zero(agg, col_name):
+    return agg[agg[col_name] > 0]['s006'].sum()
 
 
 def weighted_count(agg):
     return agg['s006'].sum()
 
 
-def weighted_mean(agg):
-    return float((agg['tax_diff']*agg['s006']).sum()) / float(agg['s006'].sum())
+def weighted_mean(agg, col_name):
+    return float((agg[col_name]*agg['s006']).sum()) / float(agg['s006'].sum())
 
 
-def weighted_sum(agg):
-    return (agg['tax_diff']*agg['s006']).sum()
+def weighted_sum(agg, col_name):
+    return (agg[col_name]*agg['s006']).sum()
 
 
-def weighted_perc_inc(agg):
-    return float(weighted_count_gt_zero(agg)) / float(weighted_count(agg))
+def weighted_perc_inc(agg, col_name):
+    return float(weighted_count_gt_zero(agg, col_name)) / float(weighted_count(agg))
 
 
-def weighted_perc_dec(agg):
-    return float(weighted_count_lt_zero(agg)) / float(weighted_count(agg))
+def weighted_perc_dec(agg, col_name):
+    return float(weighted_count_lt_zero(agg, col_name)) / float(weighted_count(agg))
 
 
-def weighted_share_of_total(agg, total):
-    return float(weighted_sum(agg)) / float(total)
+def weighted_share_of_total(agg, col_name, total):
+    return float(weighted_sum(agg, col_name)) / float(total)
 
 
 def groupby_weighted_decile(df):
@@ -197,16 +197,16 @@ def means_and_comparisons(df, col_name, gp, weighted_total):
     """
 
     # Who has a tax cut, and who has a tax increase
-    diffs = gp.apply(weighted_count_lt_zero)
+    diffs = gp.apply(weighted_count_lt_zero, col_name)
     diffs = DataFrame(data=diffs, columns=['tax_cut'])
-    diffs['tax_inc'] = gp.apply(weighted_count_gt_zero)
+    diffs['tax_inc'] = gp.apply(weighted_count_gt_zero, col_name)
     diffs['count'] = gp.apply(weighted_count)
-    diffs['mean'] = gp.apply(weighted_mean)
-    diffs['tot_change'] = gp.apply(weighted_sum)
-    diffs['perc_inc'] = gp.apply(weighted_perc_inc)
-    diffs['perc_cut'] = gp.apply(weighted_perc_dec)
+    diffs['mean'] = gp.apply(weighted_mean, col_name)
+    diffs['tot_change'] = gp.apply(weighted_sum, col_name)
+    diffs['perc_inc'] = gp.apply(weighted_perc_inc, col_name)
+    diffs['perc_cut'] = gp.apply(weighted_perc_dec, col_name)
     diffs['share_of_change'] = gp.apply(weighted_share_of_total,
-                                        weighted_total)
+                                        col_name, weighted_total)
 
     return diffs
 


### PR DESCRIPTION
- If taxcalc is installed through a .egg file, the csv and json files
  can't be read like a regular file. Use pkg_resources to read the data

- fixes to pass in the desired column name for weighted calculations