### PR TITLE
utils.expand_array accepts arrays with None

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -62,7 +62,7 @@ class Parameters(object):
         for name, data in self._vals.items():
             cpi_inflated =  data.get('cpi_inflated', False)
             values = data['value']
-            setattr(self, name, expand_array(np.array(values),
+            setattr(self, name, expand_array(values,
                 inflate=cpi_inflated, inflation_rates=self._inflation_rates,
                 num_years=budget_years))
 
@@ -92,7 +92,7 @@ class Parameters(object):
                 cpi_inflated = mods.get(name + "_cpi", False)
 
                 if year == self.start_year and year == self.current_year:
-                    nval = expand_array(np.array(values),
+                    nval = expand_array(values,
                                         inflate=cpi_inflated,
                                         inflation_rates=self._inflation_rates,
                                         num_years=num_years_to_expand)
@@ -105,7 +105,7 @@ class Parameters(object):
                     inf_rates = [self.__rates[year + i]
                                  for i in range(0, num_years_to_expand)]
 
-                    nval = expand_array(np.array(values),
+                    nval = expand_array(values,
                                         inflate=cpi_inflated,
                                         inflation_rates=inf_rates,
                                         num_years=num_years_to_expand)
@@ -114,8 +114,8 @@ class Parameters(object):
 
                 else: # year > current_year
                     msg = ("Can't specify a parameter for a year that is in the"
-                          " future because we don't know how to fill in the "
-                          " values for the years between {0} and {1}.")
+                           " future because we don't know how to fill in the "
+                           " values for the years between {0} and {1}.")
                     raise ValueError(msg.format(self.current_year, year))
 
 

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.join(cur_path, "../"))
 import numpy as np
 import pandas as pd
 import pytest
+import numpy.testing as npt
 from pandas import DataFrame, Series
 from pandas.util.testing import assert_frame_equal
 from pandas.util.testing import assert_series_equal
@@ -48,7 +49,7 @@ def test_expand_1D_variable_rates():
     exp[:3] = exp1
     exp[3:] = exp2
     res = expand_1D(x, inflate=True, inflation_rates=irates, num_years=5)
-    assert(np.allclose(exp.astype(x.dtype, casting='unsafe'), res))
+    assert(np.allclose(exp.astype('f4', casting='unsafe'), res))
 
 
 def test_expand_1D_scalar():
@@ -56,6 +57,25 @@ def test_expand_1D_scalar():
     exp = np.array([10.0 * math.pow(1.02, i) for i in range(0, 10)])
     res = expand_1D(x, inflate=True, inflation_rates=[0.02]*10, num_years=10)
     assert(np.allclose(exp, res))
+
+
+def test_expand_1D_accept_None():
+    x = [4., 5., None]
+    irates = [0.02, 0.02, 0.02, 0.03, 0.035]
+    exp2 = []
+    cur = 5.0
+    short_x = np.array([4, 5])
+    for i in range(1, 4):
+        idx = i + len(short_x) - 1
+        cur *= (1.0 + irates[idx])
+        exp2.append(cur)
+
+    exp1 = np.array([4, 5])
+    exp = np.zeros(5)
+    exp[:2] = exp1
+    exp[2:] = exp2
+    res = expand_array(x, inflate=True, inflation_rates=irates, num_years=5)
+    assert(np.allclose(exp.astype('f4', casting='unsafe'), res))
 
 
 def test_expand_2D_short_array():
@@ -76,7 +96,7 @@ def test_expand_2D_variable_rates():
     irates = [0.02, 0.02, 0.02, 0.03, 0.035]
 
     exp2 = []
-    for i in range(1, 5):
+    for i in range(0, 4):
         idx = i + len(x) - 1
         cur = np.array(cur*(1.0 + irates[idx]))
         print("cur is ", cur)
@@ -88,6 +108,7 @@ def test_expand_2D_variable_rates():
     exp[:1] = exp1
     exp[1:] = exp2
     res = expand_2D(x, inflate=True, inflation_rates=irates, num_years=5)
+    npt.assert_array_equal(res, np.array(exp).astype('f8', casting='unsafe'))
     assert(np.allclose(exp, res))
 
 
@@ -258,3 +279,114 @@ def test_add_weighted_decile_bins():
     df = DataFrame(data=data, columns=['c00100', 's006', 'label'])
     df = add_weighted_decile_bins(df)
     assert 'bins' in df
+
+def test_expand_2D_already_filled():
+
+    _II_brk2 =  [[36000, 72250, 36500, 48600, 72500, 36250],
+                 [38000, 74000, 36900, 49400, 73800, 36900],
+                 [40000, 74900, 37450, 50200, 74900, 37450]]
+
+    res = expand_2D(_II_brk2, inflate=True, inflation_rates=[0.02]*5, num_years=3)
+
+    npt.assert_array_equal(res, np.array(_II_brk2))
+
+def test_expand_2D_partial_expand():
+
+    _II_brk2 =  [[36000, 72250, 36500, 48600, 72500, 36250],
+                 [38000, 74000, 36900, 49400, 73800, 36900],
+                 [40000, 74900, 37450, 50200, 74900, 37450]]
+
+    # We have three years worth of data, need 4 years worth,
+    # but we only need the inflation rate for year 3 to go
+    # from year 3 -> year 4
+    inf_rates = [0.02, 0.02, 0.03]
+
+    exp1 = 40000*1.03
+    exp2 = 74900*1.03
+    exp3 = 37450*1.03
+    exp4 = 50200*1.03
+    exp5 = 74900*1.03
+    exp6 = 37450*1.03
+
+    exp =  [[36000, 72250, 36500, 48600, 72500, 36250],
+            [38000, 74000, 36900, 49400, 73800, 36900],
+            [40000, 74900, 37450, 50200, 74900, 37450],
+            [exp1, exp2, exp3, exp4, exp5, exp6]]
+
+    exp = np.array(exp).astype('i4', casting='unsafe')
+
+    res = expand_2D(_II_brk2, inflate=True, inflation_rates=inf_rates, num_years=4)
+
+    npt.assert_array_equal(res, exp)
+
+
+def test_strip_Nones():
+
+    x = [None, None]
+    assert strip_Nones(x) == []
+
+    x = [1, 2, None]
+    assert strip_Nones(x) == [1, 2]
+
+    x = [[1, 2, 3], [4, None, None]]
+    assert strip_Nones(x) == [[1, 2, 3], [4, -1, -1]]
+
+
+def test_expand_2D_accept_None():
+
+    _II_brk2 =  [[36000, 72250, 36500, 48600, 72500, 36250],
+                 [38000, 74000, 36900, 49400, 73800, 36900],
+                 [40000, 74900, 37450, 50200, 74900, 37450],
+                 [41000, None, None, None, None, None]]
+
+    exp1 = 74900*1.02
+    exp2 = 37450*1.02
+    exp3 = 50200*1.02
+    exp4 = 74900*1.02
+    exp5 = 37450*1.02
+
+    exp =  [[36000, 72250, 36500, 48600, 72500, 36250],
+            [38000, 74000, 36900, 49400, 73800, 36900],
+            [40000, 74900, 37450, 50200, 74900, 37450],
+            [41000, exp1, exp2, exp3, exp4, exp5]]
+
+    exp = np.array(exp).astype('i4', casting='unsafe')
+
+    res = expand_array(_II_brk2, inflate=True, inflation_rates=[0.02]*5, num_years=4)
+
+    npt.assert_array_equal(res, exp)
+
+
+def test_expand_2D_accept_None_additional_row():
+
+    _II_brk2 =  [[36000, 72250, 36500, 48600, 72500, 36250],
+                 [38000, 74000, 36900, 49400, 73800, 36900],
+                 [40000, 74900, 37450, 50200, 74900, 37450],
+                 [41000, None, None, None, None, None],
+                 [43000, None, None, None, None, None]]
+
+    exp1 = 74900*1.02
+    exp2 = 37450*1.02
+    exp3 = 50200*1.02
+    exp4 = 74900*1.02
+    exp5 = 37450*1.02
+
+    exp6 = exp1*1.03
+    exp7 = exp2*1.03
+    exp8 = exp3*1.03
+    exp9 = exp4*1.03
+    exp10 = exp5*1.03
+
+    exp =  [[36000, 72250, 36500, 48600, 72500, 36250],
+            [38000, 74000, 36900, 49400, 73800, 36900],
+            [40000, 74900, 37450, 50200, 74900, 37450],
+            [41000, exp1, exp2, exp3, exp4, exp5],
+            [43000, exp6, exp7, exp8, exp9, exp10]]
+
+    exp = np.array(exp).astype('i4', casting='unsafe')
+
+    inflation_rates = [0.015, 0.02, 0.02, 0.03]
+
+    res = expand_array(_II_brk2, inflate=True, inflation_rates=inflation_rates, num_years=5)
+
+    npt.assert_array_equal(res, exp)

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -65,26 +65,87 @@ def expand_2D(x, inflate, inflation_rates, num_years):
     """
 
     if isinstance(x, np.ndarray):
-        if x.shape[0] >= num_years:
+
+        #Look for -1s and create masks if present
+        last_good_row = -1
+        keep_user_data_mask = []
+        keep_calc_data_mask = []
+        has_nones = False
+        for row in x:
+            keep_user_data_mask.append([1 if i != -1 else 0 for i in row])
+            keep_calc_data_mask.append([0 if i != -1 else 1 for i in row])
+            if not np.any(row == -1):
+                last_good_row += 1
+            else:
+                has_nones = True
+
+        if x.shape[0] >= num_years and not has_nones:
             return x
         else:
-            ans = np.zeros((num_years, x.shape[1]))
-            ans[:len(x), :] = x
+
+            if has_nones:
+                c = x[:last_good_row+1]
+                keep_user_data_mask = np.array(keep_user_data_mask)
+                keep_calc_data_mask = np.array(keep_calc_data_mask)
+
+            else:
+                c = x
+
+            ans = np.zeros((num_years, c.shape[1]))
+            ans[:len(c), :] = c
             if inflate:
                 extra = []
-                cur = x[-1]
-                for i in range(1, num_years - len(x) + 1):
-                    inf_idx = i + len(x) - 1
+                cur = c[-1]
+                for i in range(0, num_years - len(c)):
+                    inf_idx = i + len(c) - 1
                     cur = np.array(cur*(1. + inflation_rates[inf_idx]))
                     extra.append(cur)
             else:
-                extra = [x[-1, :] for i in
-                         range(1, num_years - len(x) + 1)]
+                extra = [c[-1, :] for i in
+                         range(1, num_years - len(c) + 1)]
 
-            ans[len(x):, :] = extra
-            return ans.astype(x.dtype, casting='unsafe')
+            ans[len(c):, :] = extra
 
-    return expand_2D(np.array([x]), inflate, inflation_rates, num_years)
+            if has_nones:
+                # Use masks to "mask in" provided data and "mask out"
+                # data we don't need (produced in rows with a None value)
+                ans = ans * keep_calc_data_mask
+                user_vals = x * keep_user_data_mask
+                ans = ans + user_vals
+
+            return ans.astype(c.dtype, casting='unsafe')
+
+    return expand_2D(np.array(x), inflate, inflation_rates, num_years)
+
+
+def strip_Nones(x):
+    """
+    Takes a list of scalar values or a list of lists.
+    If it is a list of scalar values, when None is encountered, we
+    return everything encountered before. If a list of lists, we
+    replace None with -1 and return
+
+    Parameters:
+    -----------
+    x: list
+
+    Returns:
+    --------
+    list
+    """
+    accum = []
+    for val in x:
+        if val is None:
+            return accum
+        if not isinstance(val, list):
+            accum.append(val)
+        else:
+            for i, v in enumerate(val):
+                if v is None:
+                    val[i] = -1
+            accum.append(val)
+
+    return accum
 
 
 def expand_array(x, inflate, inflation_rates, num_years):
@@ -108,6 +169,7 @@ def expand_array(x, inflate, inflation_rates, num_years):
     -------
     expanded numpy array
     """
+    x = np.array(strip_Nones(x))
     try:
         if len(x.shape) == 1:
             return expand_1D(x, inflate, inflation_rates, num_years)


### PR DESCRIPTION
This is needed to handle variation in how a user may specify multi-valued parameters in the webapp. In particular, they may provide different numbers of values (per year) for each component of a multi-valued parameter.