### PR TITLE
Add a floor rate to the charitable deduction

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -105,13 +105,16 @@ def AGI(   _ymod1, c02500, c02700, e02615, c02900, e00100, e02500, XTOT,
     
     return (c02650, c00100, _agierr, _posagi, _ywossbe, _ywossbc, _prexmp, c04600)
 
-@iterate_jit(parameters=["puf", "ID_ps","ID_Medical_frt", "ID_Casualty_frt", "ID_Miscellaneous_frt",
-                         "ID_Charity_crt_Cash","ID_Charity_crt_Asset", "ID_prt", "ID_crt", "ID_Charity_frt"], nopython=True, puf=True)
+@iterate_jit(parameters=["puf", "ID_ps","ID_Medical_frt", "ID_Casualty_frt", 
+                         "ID_Miscellaneous_frt", "ID_Charity_crt_Cash",
+                         "ID_Charity_crt_Asset", "ID_prt", "ID_crt", 
+                         "ID_Charity_frt"], nopython=True, puf=True)
 def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
-                 e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
-                 e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
-                 MARS, _sep, c00100, ID_ps,ID_Medical_frt, ID_Casualty_frt, ID_Miscellaneous_frt,
-                 ID_Charity_crt_Cash, ID_Charity_crt_Asset, ID_prt, ID_crt, ID_Charity_frt, puf):
+                 e20500, e20400, e19200, e20550, e20600, e20950, e19500, 
+                 e19570, e19400, e19550, e19800, e20100, e20200, e20900, 
+                 e21000, e21010, MARS, _sep, c00100, ID_ps,ID_Medical_frt, 
+                 ID_Casualty_frt, ID_Miscellaneous_frt, ID_Charity_crt_Cash, 
+                 ID_Charity_crt_Asset, ID_prt, ID_crt, ID_Charity_frt, puf):
     """
     WARNING: Any additional keyword args, such as 'puf=True' here, must be passed
     to the function at the END of the argument list. If you stick the argument
@@ -184,8 +187,9 @@ def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
 
     c20400 = float(c20400)
 
-    # the variables that are casted as floats below can be either floats or ints depending
-    # on which if/else branches they follow in the above code. they need to always be the same type
+    # the variables that are casted as floats below can be either floats or 
+    # ints depending n which if/else branches they follow in the above code. 
+    # they need to always be the same type
 
     c20400 = float(c20400)
     c19200 = float(c19200)

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -159,7 +159,7 @@ def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
         lim30 = min(ID_Charity_crt_Asset * _posagi, e20100 + e20200)
         c19700 = min(0.5 * _posagi, lim30 + lim50)
 
-    charity_floor = ID_Charity_frt * _posagi
+    charity_floor = ID_Charity_frt * _posagi # frt is zero in present law
     c19700 = max(0, c19700 - charity_floor)
  
 

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -106,12 +106,12 @@ def AGI(   _ymod1, c02500, c02700, e02615, c02900, e00100, e02500, XTOT,
     return (c02650, c00100, _agierr, _posagi, _ywossbe, _ywossbc, _prexmp, c04600)
 
 @iterate_jit(parameters=["puf", "ID_ps","ID_Medical_frt", "ID_Casualty_frt", "ID_Miscellaneous_frt",
-                         "ID_Charity_crt_Cash","ID_Charity_crt_Asset", "ID_prt", "ID_crt"], nopython=True, puf=True)
+                         "ID_Charity_crt_Cash","ID_Charity_crt_Asset", "ID_prt", "ID_crt", "ID_Charity_frt"], nopython=True, puf=True)
 def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
                  e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
                  e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
                  MARS, _sep, c00100, ID_ps,ID_Medical_frt, ID_Casualty_frt, ID_Miscellaneous_frt,
-                 ID_Charity_crt_Cash, ID_Charity_crt_Asset, ID_prt, ID_crt, puf):
+                 ID_Charity_crt_Cash, ID_Charity_crt_Asset, ID_prt, ID_crt, ID_Charity_frt, puf):
     """
     WARNING: Any additional keyword args, such as 'puf=True' here, must be passed
     to the function at the END of the argument list. If you stick the argument
@@ -155,7 +155,10 @@ def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
         lim50 = min(ID_Charity_crt_Cash * _posagi, e19800)
         lim30 = min(ID_Charity_crt_Asset * _posagi, e20100 + e20200)
         c19700 = min(0.5 * _posagi, lim30 + lim50)
-    # temporary fix!??
+
+    charity_floor = ID_Charity_frt * _posagi
+    c19700 = max(0, c19700 - charity_floor)
+ 
 
     # Gross Itemized Deductions #
     c21060 = (e20900 + c17000 + c18300 + c19200 + c19700

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -814,16 +814,16 @@
 
     },
      "_ID_Charity_frt":{
-        "long_name": "Itemized Deduction: Charitable Deduction Floor (%, floor)",
+        "long_name": "Deduction for charitable contributions; floor as a percent of AGI",
         "description": "You are eligible to deduct your charitable expense when it exceeds this percentage of AGI.",
         "irs_ref": "Form , line , ",
         "notes": "This parameter allows for implementation of Option 52 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
         "start_year": 2013,
-        "col_var": "NA",
-        "row_var": "NA",
-        "row_label": "NA",
+        "col_var": "",
+        "row_var": "",
+        "row_label": "",
         "cpi_inflated": false,
-        "col_label": "NA",
+        "col_label": "",
         "value":     [0.0]        
             
     },

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -810,7 +810,22 @@
         "row_label": "",
         "cpi_inflated": false,
         "col_label": "",
-        "value":     [0.1]        
+        "value":     [0.1] 
+
+    },
+     "_ID_Charity_frt":{
+        "long_name": "Itemized Deduction: Charitable Deduction Floor (%, floor)",
+        "description": "You are eligible to deduct your charitable expense when it exceeds this percentage of AGI.",
+        "irs_ref": "Form , line , ",
+        "notes": "This parameter allows for implementation of Option 52 from https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf.",
+        "start_year": 2013,
+        "col_var": "NA",
+        "row_var": "NA",
+        "row_label": "NA",
+        "cpi_inflated": false,
+        "col_label": "NA",
+        "value":     [0.0]        
+            
     },
      "_ID_Casualty_frt":{
         "long_name": "Deduction for casualty loss; floor as a percent of AGI",


### PR DESCRIPTION
This PR adds the ability to set a floor rate for the charitable deduction. 

See issue #144.

This is [CBO budget options](https://www.cbo.gov/sites/default/files/cbofiles/attachments/49638-BudgetOptions.pdf) 52.

I am breaking PR #201 into pieces, and this is one of those. 

@Amy-Xu could you please review before I merge? 