### PR TITLE
correct SS_Income_c name and description

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -208,14 +208,14 @@ def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
                 c20750, c20400, c19200, c20800, c19700, c21060, _phase2_i,
                 _nonlimited, _limitratio, c04470, c21040)
 
-@iterate_jit(parameters=["SS_Earning_c", "FICA_ss_trt", "FICA_mc_trt"], 
+@iterate_jit(parameters=["SS_Earnings_c", "FICA_ss_trt", "FICA_mc_trt"], 
     nopython=True)
-def EI_FICA(   e00900, e02100, SS_Earning_c, e00200,
+def EI_FICA(   e00900, e02100, SS_Earnings_c, e00200,
                     e11055, e00250, e30100, FICA_ss_trt, FICA_mc_trt):
     # Earned Income and FICA #
 
     _sey = e00900 + e02100
-    _fica_ss = max(0, FICA_ss_trt * min(SS_Earning_c, e00200
+    _fica_ss = max(0, FICA_ss_trt * min(SS_Earnings_c, e00200
                  + max(0, _sey) * (1 - 0.5 * (FICA_mc_trt+FICA_ss_trt))))
     _fica_mc = max(0, FICA_mc_trt * (e00200 + max(0, _sey))
                 *(1 - 0.5 * (FICA_mc_trt+FICA_ss_trt)))
@@ -1201,11 +1201,11 @@ def NonEdCr(c87550, MARS, ETC_pe_Married, c00100, _num,
     return (c87560, c87570, c87580, c87590, c87600, c87610,
                c87620, _ctc1, _ctc2, _regcrd, _exocrd, _ctctax, c07220, c07230)
 
-@iterate_jit(parameters=['ACTC_rt', 'SS_Earning_c', 'ACTC_Income_thd', 'puf', 'ACTC_ChildNum',
+@iterate_jit(parameters=['ACTC_rt', 'SS_Earnings_c', 'ACTC_Income_thd', 'puf', 'ACTC_ChildNum',
                          'ALD_SelfEmploymentTax_HC'],
                         nopython=True, puf=True)
 def AddCTC(_nctcr, _precrd, c07220, e00200, e82882, e30100, _sey, _setax, 
-                _exact, e82880, ACTC_Income_thd, ACTC_rt, SS_Earning_c, ALD_SelfEmploymentTax_HC,
+                _exact, e82880, ACTC_Income_thd, ACTC_rt, SS_Earnings_c, ALD_SelfEmploymentTax_HC,
                 e03260, e09800, c59660, e11200, e59680, e59700, e59720,
                 _fixup, e11070, e82915, e82940, c82940, ACTC_ChildNum, puf):
 
@@ -1244,7 +1244,7 @@ def AddCTC(_nctcr, _precrd, c07220, e00200, e82882, e30100, _sey, _setax,
     # Part II of 2005 form 8812
 
     if _nctcr >= ACTC_ChildNum and c82890 < c82935:
-        c82900 = 0.0765 * min(SS_Earning_c, c82880)
+        c82900 = 0.0765 * min(SS_Earnings_c, c82880)
 
 
         c82905 = float((1-ALD_SelfEmploymentTax_HC)*e03260 + e09800)

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -208,14 +208,14 @@ def ItemDed(_posagi, e17500, e18400, e18425, e18450, e18500, e18800, e18900,
                 c20750, c20400, c19200, c20800, c19700, c21060, _phase2_i,
                 _nonlimited, _limitratio, c04470, c21040)
 
-@iterate_jit(parameters=["SS_Income_c", "FICA_ss_trt", "FICA_mc_trt"], 
+@iterate_jit(parameters=["SS_Earning_c", "FICA_ss_trt", "FICA_mc_trt"], 
     nopython=True)
-def EI_FICA(   e00900, e02100, SS_Income_c, e00200,
+def EI_FICA(   e00900, e02100, SS_Earning_c, e00200,
                     e11055, e00250, e30100, FICA_ss_trt, FICA_mc_trt):
     # Earned Income and FICA #
 
     _sey = e00900 + e02100
-    _fica_ss = max(0, FICA_ss_trt * min(SS_Income_c, e00200
+    _fica_ss = max(0, FICA_ss_trt * min(SS_Earning_c, e00200
                  + max(0, _sey) * (1 - 0.5 * (FICA_mc_trt+FICA_ss_trt))))
     _fica_mc = max(0, FICA_mc_trt * (e00200 + max(0, _sey))
                 *(1 - 0.5 * (FICA_mc_trt+FICA_ss_trt)))
@@ -1201,11 +1201,11 @@ def NonEdCr(c87550, MARS, ETC_pe_Married, c00100, _num,
     return (c87560, c87570, c87580, c87590, c87600, c87610,
                c87620, _ctc1, _ctc2, _regcrd, _exocrd, _ctctax, c07220, c07230)
 
-@iterate_jit(parameters=['ACTC_rt', 'SS_Income_c', 'ACTC_Income_thd', 'puf', 'ACTC_ChildNum',
+@iterate_jit(parameters=['ACTC_rt', 'SS_Earning_c', 'ACTC_Income_thd', 'puf', 'ACTC_ChildNum',
                          'ALD_SelfEmploymentTax_HC'],
                         nopython=True, puf=True)
 def AddCTC(_nctcr, _precrd, c07220, e00200, e82882, e30100, _sey, _setax, 
-                _exact, e82880, ACTC_Income_thd, ACTC_rt, SS_Income_c, ALD_SelfEmploymentTax_HC,
+                _exact, e82880, ACTC_Income_thd, ACTC_rt, SS_Earning_c, ALD_SelfEmploymentTax_HC,
                 e03260, e09800, c59660, e11200, e59680, e59700, e59720,
                 _fixup, e11070, e82915, e82940, c82940, ACTC_ChildNum, puf):
 
@@ -1244,7 +1244,7 @@ def AddCTC(_nctcr, _precrd, c07220, e00200, e82882, e30100, _sey, _setax,
     # Part II of 2005 form 8812
 
     if _nctcr >= ACTC_ChildNum and c82890 < c82935:
-        c82900 = 0.0765 * min(SS_Income_c, c82880)
+        c82900 = 0.0765 * min(SS_Earning_c, c82880)
 
 
         c82905 = float((1-ALD_SelfEmploymentTax_HC)*e03260 + e09800)

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -418,9 +418,9 @@
         "col_label":["0kids", "1kid", "2kids", "3+kids"],
         "value":    [[0.0765, 0.1598, 0.2106, 0.2106]]        
     },
-    "_SS_Income_c":{
-        "long_name": "Max Taxable AGI for Social Security",
-	    "description": "Taxpayers with income higher than this maximum are not subjected to social security tax.",
+    "_SS_Earning_c":{
+        "long_name": "Max Taxable Earnings for Social Security",
+	    "description": "Taxpayers with earnings higher than this maximum are not subjected to social security tax.",
         "irs_ref": "form , lines",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -418,7 +418,7 @@
         "col_label":["0kids", "1kid", "2kids", "3+kids"],
         "value":    [[0.0765, 0.1598, 0.2106, 0.2106]]        
     },
-    "_SS_Earning_c":{
+    "_SS_Earnings_c":{
         "long_name": "Max Taxable Earnings for Social Security",
 	    "description": "Taxpayers with earnings higher than this maximum are not subjected to social security tax.",
         "irs_ref": "form , lines",


### PR DESCRIPTION
This pr responds to issue #248. 

The maximum taxable earnings for social security was mislabeled maximum taxable AGI. This pr corrects the description, long_name, and param name. 

@Amy-Xu, could you review before I merge? 