### PR TITLE
Parameters.update respects current year

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -113,7 +113,12 @@ class Parameters(object):
                                         inflation_rates=inf_rates,
                                         num_years=num_years_to_expand)
 
-                    setattr(self, name, nval[num_years_to_skip:])
+                    if self.current_year > self.start_year:
+                        cur_val = getattr(self, name)
+                        offset = self.current_year - self.start_year
+                        cur_val[offset:] = nval[num_years_to_skip:]
+                    else:
+                        setattr(self, name, nval[num_years_to_skip:])
 
                 else: # year > current_year
                     msg = ("Can't specify a parameter for a year that is in the"

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -93,6 +93,14 @@ def test_update_Parameters_increment_until_mod_year():
     p.update(user_mods)
     assert_array_equal(p.STD_Aged, np.array([1400, 1100, 1100, 1400, 1400, 1199]))
 
+def test_increment_Parameters_increment_and_then_update():
+    p = Parameters(start_year=2013)
+    p.increment_year()
+    p.increment_year()
+    user_mods = {2015: { "_II_em": [4400], "_II_em_cpi": True}}
+    p.update(user_mods)
+    assert_array_equal(p._II_em[:3], np.array([3900, 3950, 4400]))
+    assert p.II_em == 4400
 
 def test_parameters_get_default_start_year():
     paramdata = taxcalc.parameters.default_data(start_year=2015, metadata=True)


### PR DESCRIPTION
If the current year > start year for a Parameters object,
the update must respect that difference when updating a multi-year
Parameter.

This is a fix for https://github.com/OpenSourcePolicyCenter/Tax-Calculator/issues/252