### PR TITLE
Parameters.update now uses default cpi flags

### DIFF
--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -86,13 +86,18 @@ class Parameters(object):
         if not all(isinstance(k, int) for k in year_mods.keys()):
             raise ValueError("Every key must be a year, e.g. 2011, 2012, etc.")
 
+        defaults = default_data(metadata=True)
         for year, mods in year_mods.items():
 
             num_years_to_expand = (self.start_year + self.budget_years) - year
             for name, values in mods.items():
                 if name.endswith("_cpi"):
                     continue
-                cpi_inflated = mods.get(name + "_cpi", False)
+                if name in defaults:
+                    default_cpi = defaults[name].get('cpi_inflated', False)
+                else:
+                    default_cpi = False
+                cpi_inflated = mods.get(name + "_cpi", default_cpi)
 
                 if year == self.start_year and year == self.current_year:
                     nval = expand_array(values,

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -132,7 +132,7 @@ def test_make_Calculator_mods():
     # Create a Public Use File object
     puf = Records(tax_dta)
 
-    calc2 = calculator(params, puf, _II_em = np.array([4000]))
+    calc2 = calculator(params, puf, _II_em = np.array([4000]), _II_em_cpi=False)
     assert all(calc2._II_em == np.array([4000]))
 
 
@@ -147,7 +147,7 @@ def test_make_Calculator_json():
     user_mods = """{"1991": { "_STD_Aged": [[1500, 1250, 1200, 1500, 1500, 1200 ]],
                      "_STD_Aged_cpi": false}}"""
 
-    calc2 = calculator(params, puf, mods=user_mods, _II_em=np.array([4000]))
+    calc2 = calculator(params, puf, mods=user_mods, _II_em_cpi=False, _II_em=np.array([4000]))
     assert calc2.II_em == 4000
     assert_array_equal(calc2._II_em, np.array([4000]*12))
     exp_STD_Aged = [[1500, 1250, 1200, 1500, 1500, 1200 ]] * 12
@@ -165,6 +165,7 @@ def test_make_Calculator_user_mods_as_dict():
 
     user_mods = {1991: { "_STD_Aged": [[1400, 1200]] }}
     user_mods[1991]['_II_em'] = [3925, 4000, 4100]
+    user_mods[1991]['_II_em_cpi'] = False
     calc2 = calculator(params, puf, mods=user_mods)
     assert calc2.II_em == 3925
     exp_II_em = [3925, 4000] + [4100] * 10

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -85,6 +85,18 @@ def test_update_Parameters_raises_on_future_year():
         user_mods = {2015: { "_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]] }}
         p.update(user_mods)
 
+def test_update_Parameters_maintains_default_cpi_flags():
+    p = Parameters(start_year=2013)
+    p.increment_year()
+    p.increment_year()
+    user_mods = {2015: { "_II_em": [4300]}}
+    p.update(user_mods)
+    #_II_em has a default cpi_flag of True, so by incrementing the year,
+    #the current year value should increase, and therefore not be 4300
+    p.increment_year()
+    assert p.II_em != 4300
+
+
 def test_update_Parameters_increment_until_mod_year():
     p = Parameters(start_year=2013)
     p.increment_year()


### PR DESCRIPTION
When a parameter is updated, if the cpi flag is specified in
params.json we use that default value to determine whether or not
we inflate the value (assuming we are not given the corresponding cpi flag as part of the update)