### PR TITLE
remove Calculator attribute access to params/records 

### DIFF
--- a/docs/notebooks/10_Minutes_to_Taxcalc.ipynb
+++ b/docs/notebooks/10_Minutes_to_Taxcalc.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:c034302df5d00e1743f71fdb344b06ab4d51c15254c596d40155753154e45686"
+  "signature": "sha256:820dace334fa6ed2c08ffed87b1dfba5f93af849f3595372b9d81281ba4c4640"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -48,7 +48,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 1
+     "prompt_number": 3
     },
     {
      "cell_type": "heading",
@@ -66,7 +66,7 @@
       "#Create a Public Use File object\n",
       "tax_dta = pd.read_csv(\"../../puf.csv\")\n",
       "# Create a default Parameters object\n",
-      "params = Parameters(start_year=2013)\n",
+      "params = Params(start_year=2013)\n",
       "records = Records(tax_dta)\n",
       "# Create a Calculator\n",
       "calcX = Calculator(records=records, parameters=params)\n"
@@ -90,7 +90,7 @@
        ]
       }
      ],
-     "prompt_number": 2
+     "prompt_number": 4
     },
     {
      "cell_type": "heading",
@@ -109,7 +109,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 3
+     "prompt_number": 5
     },
     {
      "cell_type": "heading",
@@ -128,7 +128,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 4
+     "prompt_number": 6
     },
     {
      "cell_type": "code",
@@ -145,7 +145,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 5
+     "prompt_number": 7
     },
     {
      "cell_type": "code",
@@ -156,7 +156,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 6
+     "prompt_number": 8
     },
     {
      "cell_type": "code",
@@ -420,7 +420,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 7,
+       "prompt_number": 9,
        "text": [
         "                                   Returns               AGI  \\\n",
         "(0, 14670155.836]               14,670,113  -114,498,590,791   \n",
@@ -541,7 +541,7 @@
        ]
       }
      ],
-     "prompt_number": 7
+     "prompt_number": 9
     },
     {
      "cell_type": "heading",
@@ -564,7 +564,7 @@
      "collapsed": false,
      "input": [
       "# User specified Plans\n",
-      "params2 = Parameters(start_year=2013)\n",
+      "params2 = Params(start_year=2013)\n",
       "#Create a Public Use File object\n",
       "tax_dta = pd.read_csv(\"../../puf.csv\")\n",
       "# Create a default Parameters object\n",
@@ -575,7 +575,7 @@
       "user_mods = {2013: myvars}\n",
       "\n",
       "# Create a Calculator\n",
-      "calcY = calculator(parameters=params2, records=records2, mods=user_mods)"
+      "calcY = calculator(params=params2, records=records2, mods=user_mods)"
      ],
      "language": "python",
      "metadata": {},
@@ -588,7 +588,7 @@
        ]
       }
      ],
-     "prompt_number": 8
+     "prompt_number": 10
     },
     {
      "cell_type": "code",
@@ -599,7 +599,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 9
+     "prompt_number": 11
     },
     {
      "cell_type": "heading",
@@ -618,7 +618,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 10
+     "prompt_number": 12
     },
     {
      "cell_type": "code",
@@ -629,7 +629,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 11
+     "prompt_number": 13
     },
     {
      "cell_type": "code",
@@ -893,7 +893,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 12,
+       "prompt_number": 14,
        "text": [
         "                                   Returns               AGI  \\\n",
         "(0, 14670155.836]               14,670,113  -114,498,590,791   \n",
@@ -1014,7 +1014,7 @@
        ]
       }
      ],
-     "prompt_number": 12
+     "prompt_number": 14
     },
     {
      "cell_type": "heading",
@@ -1033,7 +1033,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 13
+     "prompt_number": 15
     },
     {
      "cell_type": "code",
@@ -1048,7 +1048,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 14
+     "prompt_number": 16
     },
     {
      "cell_type": "code",
@@ -1204,7 +1204,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 15,
+       "prompt_number": 17,
        "text": [
         "                                Inds. w/ Tax Cut  Inds. w/ Tax Increase  \\\n",
         "(0, 14670155.836]                             20                  5,511   \n",
@@ -1260,7 +1260,7 @@
        ]
       }
      ],
-     "prompt_number": 15
+     "prompt_number": 17
     },
     {
      "cell_type": "heading",
@@ -1295,7 +1295,7 @@
        ]
       }
      ],
-     "prompt_number": 16
+     "prompt_number": 18
     },
     {
      "cell_type": "code",
@@ -1453,7 +1453,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 17,
+       "prompt_number": 19,
        "text": [
         "                                Inds. w/ Tax Cut  Inds. w/ Tax Increase  \\\n",
         "(0, 15271290.822]                             76                  5,791   \n",
@@ -1509,7 +1509,7 @@
        ]
       }
      ],
-     "prompt_number": 17
+     "prompt_number": 19
     },
     {
      "cell_type": "markdown",
@@ -1523,7 +1523,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 17
+     "prompt_number": 19
     },
     {
      "cell_type": "code",
@@ -1532,7 +1532,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 18
+     "prompt_number": 19
     }
    ],
    "metadata": {}

--- a/docs/notebooks/10_Minutes_to_Taxcalc.ipynb
+++ b/docs/notebooks/10_Minutes_to_Taxcalc.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:820dace334fa6ed2c08ffed87b1dfba5f93af849f3595372b9d81281ba4c4640"
+  "signature": "sha256:1279990f9f99a2327802b570ebd41176285ef49441b00f84b22bc628a8b5e000"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -48,7 +48,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 3
+     "prompt_number": 1
     },
     {
      "cell_type": "heading",
@@ -66,10 +66,10 @@
       "#Create a Public Use File object\n",
       "tax_dta = pd.read_csv(\"../../puf.csv\")\n",
       "# Create a default Parameters object\n",
-      "params = Params(start_year=2013)\n",
-      "records = Records(tax_dta)\n",
+      "params1 = Parameters(start_year=2013)\n",
+      "records1 = Records(tax_dta)\n",
       "# Create a Calculator\n",
-      "calcX = Calculator(records=records, parameters=params)\n"
+      "calcX = Calculator(records=records1, params=params1)\n"
      ],
      "language": "python",
      "metadata": {},
@@ -90,7 +90,7 @@
        ]
       }
      ],
-     "prompt_number": 4
+     "prompt_number": 2
     },
     {
      "cell_type": "heading",
@@ -109,7 +109,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 5
+     "prompt_number": 3
     },
     {
      "cell_type": "heading",
@@ -128,7 +128,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 6
+     "prompt_number": 4
     },
     {
      "cell_type": "code",
@@ -145,7 +145,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 7
+     "prompt_number": 5
     },
     {
      "cell_type": "code",
@@ -156,7 +156,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 8
+     "prompt_number": 6
     },
     {
      "cell_type": "code",
@@ -420,7 +420,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 9,
+       "prompt_number": 7,
        "text": [
         "                                   Returns               AGI  \\\n",
         "(0, 14670155.836]               14,670,113  -114,498,590,791   \n",
@@ -541,7 +541,7 @@
        ]
       }
      ],
-     "prompt_number": 9
+     "prompt_number": 7
     },
     {
      "cell_type": "heading",
@@ -564,7 +564,7 @@
      "collapsed": false,
      "input": [
       "# User specified Plans\n",
-      "params2 = Params(start_year=2013)\n",
+      "params2 = Parameters(start_year=2013)\n",
       "#Create a Public Use File object\n",
       "tax_dta = pd.read_csv(\"../../puf.csv\")\n",
       "# Create a default Parameters object\n",
@@ -588,7 +588,7 @@
        ]
       }
      ],
-     "prompt_number": 10
+     "prompt_number": 9
     },
     {
      "cell_type": "code",
@@ -599,7 +599,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 11
+     "prompt_number": 10
     },
     {
      "cell_type": "heading",
@@ -618,7 +618,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 12
+     "prompt_number": 11
     },
     {
      "cell_type": "code",
@@ -629,7 +629,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 13
+     "prompt_number": 12
     },
     {
      "cell_type": "code",
@@ -893,7 +893,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 14,
+       "prompt_number": 13,
        "text": [
         "                                   Returns               AGI  \\\n",
         "(0, 14670155.836]               14,670,113  -114,498,590,791   \n",
@@ -1014,7 +1014,7 @@
        ]
       }
      ],
-     "prompt_number": 14
+     "prompt_number": 13
     },
     {
      "cell_type": "heading",
@@ -1033,7 +1033,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 15
+     "prompt_number": 14
     },
     {
      "cell_type": "code",
@@ -1048,7 +1048,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 16
+     "prompt_number": 15
     },
     {
      "cell_type": "code",
@@ -1204,7 +1204,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 17,
+       "prompt_number": 16,
        "text": [
         "                                Inds. w/ Tax Cut  Inds. w/ Tax Increase  \\\n",
         "(0, 14670155.836]                             20                  5,511   \n",
@@ -1260,7 +1260,7 @@
        ]
       }
      ],
-     "prompt_number": 17
+     "prompt_number": 16
     },
     {
      "cell_type": "heading",
@@ -1295,7 +1295,7 @@
        ]
       }
      ],
-     "prompt_number": 18
+     "prompt_number": 17
     },
     {
      "cell_type": "code",
@@ -1453,7 +1453,7 @@
        ],
        "metadata": {},
        "output_type": "pyout",
-       "prompt_number": 19,
+       "prompt_number": 18,
        "text": [
         "                                Inds. w/ Tax Cut  Inds. w/ Tax Increase  \\\n",
         "(0, 15271290.822]                             76                  5,791   \n",
@@ -1509,7 +1509,7 @@
        ]
       }
      ],
-     "prompt_number": 19
+     "prompt_number": 18
     },
     {
      "cell_type": "markdown",
@@ -1522,8 +1522,7 @@
      "input": [],
      "language": "python",
      "metadata": {},
-     "outputs": [],
-     "prompt_number": 19
+     "outputs": []
     },
     {
      "cell_type": "code",

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -4,7 +4,7 @@ import math
 import numpy as np
 from .utils import *
 from .functions import *
-from .parameters import Parameters
+from .parameters import Params
 from .records import Records
 import copy
 
@@ -19,7 +19,7 @@ def add_df(alldfs, df):
             alldfs[dup_index] = df[col]
 
 
-def calculator(parameters, records, mods="", **kwargs):
+def calculator(params, records, mods="", **kwargs):
     update_mods = {}
     if mods:
         if isinstance(mods, str):
@@ -30,7 +30,7 @@ def calculator(parameters, records, mods="", **kwargs):
         else:
             update_mods.update(mods)
 
-    final_mods = toolz.merge_with(toolz.merge, update_mods, {parameters.current_year: kwargs})
+    final_mods = toolz.merge_with(toolz.merge, update_mods, {params.current_year: kwargs})
 
     if not all(isinstance(yr, int) for yr in final_mods):
         raise ValueError("All keys in mods must be years")
@@ -38,13 +38,13 @@ def calculator(parameters, records, mods="", **kwargs):
         max_yr = max(yr for yr in final_mods)
     else:
         max_yr = 0
-    if (parameters.current_year < max_yr):
+    if (params.current_year < max_yr):
         msg = ("Modifications are for year {0} and Parameters are for"
                " year {1}. Parameters will be advanced to year {0}")
-        print(msg.format(max_yr, parameters.current_year))
+        print(msg.format(max_yr, params.current_year))
 
-    while parameters.current_year < max_yr:
-        parameters.increment_year()
+    while params.current_year < max_yr:
+        params.increment_year()
 
     if (records.current_year < max_yr):
         msg = ("Modifications are for year {0} and Records are for"
@@ -54,8 +54,8 @@ def calculator(parameters, records, mods="", **kwargs):
     while records.current_year < max_yr:
         records.increment_year()
 
-    parameters.update(final_mods)
-    calc = Calculator(parameters, records)
+    params.update(final_mods)
+    calc = Calculator(params, records)
     return calc
 
 class Calculator(object):
@@ -72,17 +72,17 @@ class Calculator(object):
 
         rfname: filename for Records
         """
-        params = Parameters.from_file(pfname, **kwargs)
+        params = Params.from_file(pfname, **kwargs)
         recs = Records.from_file(rfname, **kwargs)
         return cls(params, recs)
 
 
-    def __init__(self, parameters=None, records=None, sync_years=True, **kwargs):
+    def __init__(self, params=None, records=None, sync_years=True, **kwargs):
 
-        if isinstance(parameters, Parameters):
-            self._parameters = parameters
+        if isinstance(params, Params):
+            self._params = params
         else:
-            self._parameters = Parameters.from_file(parameters, **kwargs)
+            self._params = Params.from_file(params, **kwargs)
 
         if records is None:
             raise ValueError("Must supply tax records path or Records object")
@@ -93,22 +93,22 @@ class Calculator(object):
         if sync_years and self._records.current_year==2008:
             print("You loaded data for "+str(self._records.current_year)+'.')
 
-            while self._records.current_year < self._parameters.current_year:
+            while self._records.current_year < self._params.current_year:
                 self._records.increment_year()
 
             print("Your data have beeen extrapolated to "+str(self._records.current_year)+".")
 
-        assert self._parameters.current_year == self._records.current_year
+        assert self._params.current_year == self._records.current_year
 
     def __deepcopy__(self, memo):
         import copy
-        params = copy.deepcopy(self._parameters)
+        params = copy.deepcopy(self._params)
         recs = copy.deepcopy(self._records)
         return Calculator(params, recs)
 
     @property
-    def parameters(self):
-        return self._parameters
+    def params(self):
+        return self._params
 
     @property
     def records(self):
@@ -119,8 +119,8 @@ class Calculator(object):
         Only allowed attributes on a Calculator are 'parameters' and 'records'
         """
 
-        if hasattr(self.parameters, name):
-            return getattr(self.parameters, name)
+        if hasattr(self.params, name):
+            return getattr(self.params, name)
         elif hasattr(self.records, name):
             return getattr(self.records, name)
         else:
@@ -134,12 +134,12 @@ class Calculator(object):
         Only allowed attributes on a Calculator are 'parameters' and 'records'
         """
 
-        if name == "_parameters" or name == "_records":
+        if name == "_params" or name == "_records":
             self.__dict__[name] = val
             return
 
-        if hasattr(self.parameters, name):
-            return setattr(self.parameters, name, val)
+        if hasattr(self.params, name):
+            return setattr(self.params, name, val)
         elif hasattr(self.records, name):
             return setattr(self.records, name, val)
         else:
@@ -151,7 +151,7 @@ class Calculator(object):
             return self.__dict__[val]
         else:
             try:
-                return getattr(self.parameters, val)
+                return getattr(self.params, val)
             except AttributeError:
                 try:
                     return getattr(self.records, val)
@@ -162,77 +162,77 @@ class Calculator(object):
 
 
     def calc_all(self):
-        FilingStatus(self.parameters, self.records)
-        Adj(self.parameters, self.records)
-        CapGains(self.parameters, self.records)
-        SSBenefits(self.parameters, self.records)
-        AGI(self.parameters, self.records)
-        ItemDed(self.parameters, self.records)
-        EI_FICA(self.parameters, self.records)
-        AMED(self.parameters, self.records)
-        StdDed(self.parameters, self.records)
-        XYZD(self.parameters, self.records)
-        NonGain(self.parameters, self.records)
-        TaxGains(self.parameters, self.records)
-        MUI(self.parameters, self.records)
-        AMTI(self.parameters, self.records)
-        F2441(self.parameters, self.records)
-        DepCareBen(self.parameters, self.records)
-        ExpEarnedInc(self.parameters, self.records)
-        RateRed(self.parameters, self.records)
-        NumDep(self.parameters, self.records)
-        ChildTaxCredit(self.parameters, self.records)
-        AmOppCr(self.parameters, self.records)
-        LLC(self.parameters, self.records)
-        RefAmOpp(self.parameters, self.records)
-        NonEdCr(self.parameters, self.records)
-        AddCTC(self.parameters, self.records)
-        F5405(self.parameters, self.records)
-        C1040(self.parameters, self.records)
-        DEITC(self.parameters, self.records)
-        OSPC_TAX(self.parameters, self.records)
+        FilingStatus(self.params, self.records)
+        Adj(self.params, self.records)
+        CapGains(self.params, self.records)
+        SSBenefits(self.params, self.records)
+        AGI(self.params, self.records)
+        ItemDed(self.params, self.records)
+        EI_FICA(self.params, self.records)
+        AMED(self.params, self.records)
+        StdDed(self.params, self.records)
+        XYZD(self.params, self.records)
+        NonGain(self.params, self.records)
+        TaxGains(self.params, self.records)
+        MUI(self.params, self.records)
+        AMTI(self.params, self.records)
+        F2441(self.params, self.records)
+        DepCareBen(self.params, self.records)
+        ExpEarnedInc(self.params, self.records)
+        RateRed(self.params, self.records)
+        NumDep(self.params, self.records)
+        ChildTaxCredit(self.params, self.records)
+        AmOppCr(self.params, self.records)
+        LLC(self.params, self.records)
+        RefAmOpp(self.params, self.records)
+        NonEdCr(self.params, self.records)
+        AddCTC(self.params, self.records)
+        F5405(self.params, self.records)
+        C1040(self.params, self.records)
+        DEITC(self.params, self.records)
+        OSPC_TAX(self.params, self.records)
 
     def calc_all_test(self):
         all_dfs = []
-        add_df(all_dfs, FilingStatus(self.parameters, self.records))
-        add_df(all_dfs, Adj(self.parameters, self.records))
-        add_df(all_dfs, CapGains(self.parameters, self.records))
-        add_df(all_dfs, SSBenefits(self.parameters, self.records))
-        add_df(all_dfs, AGI(self.parameters, self.records))
-        add_df(all_dfs, ItemDed(self.parameters, self.records))
-        add_df(all_dfs, EI_FICA(self.parameters, self.records))
-        add_df(all_dfs, AMED(self.parameters, self.records))
-        add_df(all_dfs, StdDed(self.parameters, self.records))
-        add_df(all_dfs, XYZD(self.parameters, self.records))
-        add_df(all_dfs, NonGain(self.parameters, self.records))
-        add_df(all_dfs, TaxGains(self.parameters, self.records))
-        add_df(all_dfs, MUI(self.parameters, self.records))
-        add_df(all_dfs, AMTI(self.parameters, self.records))
-        add_df(all_dfs, F2441(self.parameters, self.records))
-        add_df(all_dfs, DepCareBen(self.parameters, self.records))
-        add_df(all_dfs, ExpEarnedInc(self.parameters, self.records))
-        add_df(all_dfs, RateRed(self.parameters, self.records))
-        add_df(all_dfs, NumDep(self.parameters, self.records))
-        add_df(all_dfs, ChildTaxCredit(self.parameters, self.records))
-        add_df(all_dfs, AmOppCr(self.parameters, self.records))
-        add_df(all_dfs, LLC(self.parameters, self.records))
-        add_df(all_dfs, RefAmOpp(self.parameters, self.records))
-        add_df(all_dfs, NonEdCr(self.parameters, self.records))
-        add_df(all_dfs, AddCTC(self.parameters, self.records))
-        add_df(all_dfs, F5405(self.parameters, self.records))
-        add_df(all_dfs, C1040(self.parameters, self.records))
-        add_df(all_dfs, DEITC(self.parameters, self.records))
-        add_df(all_dfs, OSPC_TAX(self.parameters, self.records))
+        add_df(all_dfs, FilingStatus(self.params, self.records))
+        add_df(all_dfs, Adj(self.params, self.records))
+        add_df(all_dfs, CapGains(self.params, self.records))
+        add_df(all_dfs, SSBenefits(self.params, self.records))
+        add_df(all_dfs, AGI(self.params, self.records))
+        add_df(all_dfs, ItemDed(self.params, self.records))
+        add_df(all_dfs, EI_FICA(self.params, self.records))
+        add_df(all_dfs, AMED(self.params, self.records))
+        add_df(all_dfs, StdDed(self.params, self.records))
+        add_df(all_dfs, XYZD(self.params, self.records))
+        add_df(all_dfs, NonGain(self.params, self.records))
+        add_df(all_dfs, TaxGains(self.params, self.records))
+        add_df(all_dfs, MUI(self.params, self.records))
+        add_df(all_dfs, AMTI(self.params, self.records))
+        add_df(all_dfs, F2441(self.params, self.records))
+        add_df(all_dfs, DepCareBen(self.params, self.records))
+        add_df(all_dfs, ExpEarnedInc(self.params, self.records))
+        add_df(all_dfs, RateRed(self.params, self.records))
+        add_df(all_dfs, NumDep(self.params, self.records))
+        add_df(all_dfs, ChildTaxCredit(self.params, self.records))
+        add_df(all_dfs, AmOppCr(self.params, self.records))
+        add_df(all_dfs, LLC(self.params, self.records))
+        add_df(all_dfs, RefAmOpp(self.params, self.records))
+        add_df(all_dfs, NonEdCr(self.params, self.records))
+        add_df(all_dfs, AddCTC(self.params, self.records))
+        add_df(all_dfs, F5405(self.params, self.records))
+        add_df(all_dfs, C1040(self.params, self.records))
+        add_df(all_dfs, DEITC(self.params, self.records))
+        add_df(all_dfs, OSPC_TAX(self.params, self.records))
         totaldf = pd.concat(all_dfs, axis=1)
         return totaldf
 
     def increment_year(self):
         self.records.increment_year()
-        self.parameters.increment_year()
+        self.params.increment_year()
 
     @property
     def current_year(self):
-        return self.parameters.current_year
+        return self.params.current_year
 
 
     def mtr(self, income_type_string, diff = 100):

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -4,7 +4,7 @@ import math
 import numpy as np
 from .utils import *
 from .functions import *
-from .parameters import Params
+from .parameters import Parameters
 from .records import Records
 import copy
 
@@ -72,17 +72,17 @@ class Calculator(object):
 
         rfname: filename for Records
         """
-        params = Params.from_file(pfname, **kwargs)
+        params = Parameters.from_file(pfname, **kwargs)
         recs = Records.from_file(rfname, **kwargs)
         return cls(params, recs)
 
 
     def __init__(self, params=None, records=None, sync_years=True, **kwargs):
 
-        if isinstance(params, Params):
+        if isinstance(params, Parameters):
             self._params = params
         else:
-            self._params = Params.from_file(params, **kwargs)
+            self._params = Parameters.from_file(params, **kwargs)
 
         if records is None:
             raise ValueError("Must supply tax records path or Records object")

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -100,11 +100,7 @@ class Calculator(object):
 
         assert self._params.current_year == self._records.current_year
 
-    def __deepcopy__(self, memo):
-        import copy
-        params = copy.deepcopy(self._params)
-        recs = copy.deepcopy(self._records)
-        return Calculator(params, recs)
+ 
 
     @property
     def params(self):

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -114,52 +114,6 @@ class Calculator(object):
     def records(self):
         return self._records
 
-    # def __getattr__(self, name):
-    #     """
-    #     Only allowed attributes on a Calculator are 'parameters' and 'records'
-    #     """
-
-    #     if hasattr(self.params, name):
-    #         return getattr(self.params, name)
-    #     elif hasattr(self.records, name):
-    #         return getattr(self.records, name)
-    #     else:
-    #         try:
-    #             self.__dict__[name]
-    #         except KeyError:
-    #             raise AttributeError(name + " not found")
-
-    # def __setattr__(self, name, val):
-    #     """
-    #     Only allowed attributes on a Calculator are 'parameters' and 'records'
-    #     """
-
-    #     if name == "_params" or name == "_records":
-    #         self.__dict__[name] = val
-    #         return
-
-    #     if hasattr(self.params, name):
-    #         return setattr(self.params, name, val)
-    #     elif hasattr(self.records, name):
-    #         return setattr(self.records, name, val)
-    #     else:
-    #         self.__dict__[name] = val
-
-    # def __getitem__(self, val):
-
-    #     if val in self.__dict__:
-    #         return self.__dict__[val]
-    #     else:
-    #         try:
-    #             return getattr(self.params, val)
-    #         except AttributeError:
-    #             try:
-    #                 return getattr(self.records, val)
-    #             except AttributeError:
-    #                 raise
-
-
-
 
     def calc_all(self):
         FilingStatus(self.params, self.records)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -114,49 +114,49 @@ class Calculator(object):
     def records(self):
         return self._records
 
-    def __getattr__(self, name):
-        """
-        Only allowed attributes on a Calculator are 'parameters' and 'records'
-        """
+    # def __getattr__(self, name):
+    #     """
+    #     Only allowed attributes on a Calculator are 'parameters' and 'records'
+    #     """
 
-        if hasattr(self.params, name):
-            return getattr(self.params, name)
-        elif hasattr(self.records, name):
-            return getattr(self.records, name)
-        else:
-            try:
-                self.__dict__[name]
-            except KeyError:
-                raise AttributeError(name + " not found")
+    #     if hasattr(self.params, name):
+    #         return getattr(self.params, name)
+    #     elif hasattr(self.records, name):
+    #         return getattr(self.records, name)
+    #     else:
+    #         try:
+    #             self.__dict__[name]
+    #         except KeyError:
+    #             raise AttributeError(name + " not found")
 
-    def __setattr__(self, name, val):
-        """
-        Only allowed attributes on a Calculator are 'parameters' and 'records'
-        """
+    # def __setattr__(self, name, val):
+    #     """
+    #     Only allowed attributes on a Calculator are 'parameters' and 'records'
+    #     """
 
-        if name == "_params" or name == "_records":
-            self.__dict__[name] = val
-            return
+    #     if name == "_params" or name == "_records":
+    #         self.__dict__[name] = val
+    #         return
 
-        if hasattr(self.params, name):
-            return setattr(self.params, name, val)
-        elif hasattr(self.records, name):
-            return setattr(self.records, name, val)
-        else:
-            self.__dict__[name] = val
+    #     if hasattr(self.params, name):
+    #         return setattr(self.params, name, val)
+    #     elif hasattr(self.records, name):
+    #         return setattr(self.records, name, val)
+    #     else:
+    #         self.__dict__[name] = val
 
-    def __getitem__(self, val):
+    # def __getitem__(self, val):
 
-        if val in self.__dict__:
-            return self.__dict__[val]
-        else:
-            try:
-                return getattr(self.params, val)
-            except AttributeError:
-                try:
-                    return getattr(self.records, val)
-                except AttributeError:
-                    raise
+    #     if val in self.__dict__:
+    #         return self.__dict__[val]
+    #     else:
+    #         try:
+    #             return getattr(self.params, val)
+    #         except AttributeError:
+    #             try:
+    #                 return getattr(self.records, val)
+    #             except AttributeError:
+    #                 raise
 
 
 
@@ -282,61 +282,61 @@ class Calculator(object):
        for i in range(0,num_years):
            calc.calc_all()
            
-           row_years.append(calc._current_year)
+           row_years.append(calc.params._current_year)
 
            #totoal number of records
-           returns = calc.s006.sum()
+           returns = calc.records.s006.sum()
 
            #AGI
-           agi = (calc.c00100*calc.s006).sum()
+           agi = (calc.records.c00100*calc.records.s006).sum()
 
            #number of itemizers
-           ID1= calc.c04470 * calc.s006
-           STD1 = calc._standard*calc.s006
-           deduction = np.maximum(calc.c04470, calc._standard)
+           ID1= calc.records.c04470 * calc.records.s006
+           STD1 = calc.records._standard*calc.records.s006
+           deduction = np.maximum(calc.records.c04470, calc.records._standard)
 
            #STD1 = (calc.c04100 + calc.c04200)*calc.s006
-           NumItemizer1 = calc.s006[(calc.c04470>0) * (calc.c00100>0)].sum()
+           NumItemizer1 = calc.records.s006[(calc.records.c04470>0) * (calc.records.c00100>0)].sum()
 
            #itemized deduction
-           ID = ID1[calc.c04470>0].sum()
+           ID = ID1[calc.records.c04470>0].sum()
 
-           NumSTD = calc.s006[(calc._standard>0) * (calc.c00100>0)].sum()
+           NumSTD = calc.records.s006[(calc.records._standard>0) * (calc.records.c00100>0)].sum()
            #standard deduction
-           STD = STD1[(calc._standard>0) * (calc.c00100>0)].sum()
+           STD = STD1[(calc.records._standard>0) * (calc.records.c00100>0)].sum()
 
            #personal exemption
-           PE = (calc.c04600*calc.s006)[calc.c00100>0].sum()
+           PE = (calc.records.c04600*calc.records.s006)[calc.records.c00100>0].sum()
 
            #taxable income
-           taxinc = (calc.c04800*calc.s006).sum()
+           taxinc = (calc.records.c04800*calc.records.s006).sum()
 
            #regular tax
-           regular_tax = (calc.c05200*calc.s006).sum()
+           regular_tax = (calc.records.c05200*calc.records.s006).sum()
 
            #AMT income
-           AMTI = (calc.c62100*calc.s006).sum()
+           AMTI = (calc.records.c62100*calc.records.s006).sum()
 
            #total AMTs
-           AMT = (calc.c09600*calc.s006).sum()
+           AMT = (calc.records.c09600*calc.records.s006).sum()
 
            #number of people paying AMT
-           NumAMT1 = calc.s006[calc.c09600>0].sum()
+           NumAMT1 = calc.records.s006[calc.records.c09600>0].sum()
 
            #tax before credits 
-           tax_bf_credits = (calc.c05800*calc.s006).sum()
+           tax_bf_credits = (calc.records.c05800*calc.records.s006).sum()
 
            #tax before nonrefundable credits 09200
-           tax_bf_nonrefundable = (calc.c09200*calc.s006).sum()
+           tax_bf_nonrefundable = (calc.records.c09200*calc.records.s006).sum()
 
            #refundable credits
-           refundable = (calc._refund*calc.s006).sum()
+           refundable = (calc.records._refund*calc.records.s006).sum()
 
            #nonrefuncable credits
-           nonrefundable = (calc.c07100*calc.s006).sum()
+           nonrefundable = (calc.records.c07100*calc.records.s006).sum()
 
            #ospc_tax
-           revenue1 = (calc._ospctax * calc.s006).sum()
+           revenue1 = (calc.records._ospctax * calc.records.s006).sum()
 
 
            table.append([returns/math.pow(10,6),agi/math.pow(10,9),NumItemizer1/math.pow(10,6), 

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -6,7 +6,7 @@ from pkg_resources import resource_stream, Requirement
 
 DEFAULT_START_YEAR = 2013
 
-class Params(object):
+class Parameters(object):
 
 
     CUR_PATH = os.path.abspath(os.path.dirname(__file__))
@@ -159,7 +159,7 @@ class Params(object):
 
 def default_data(metadata=False, start_year=None):
     """ Retreive of default parameters """
-    parampath = Params.params_path
+    parampath = Parameters.params_path
     if not os.path.exists(parampath):
         path_in_egg = os.path.join("taxcalc", Params.PARAM_FILENAME)
         buf = resource_stream(Requirement.parse("taxcalc"), path_in_egg)
@@ -167,7 +167,7 @@ def default_data(metadata=False, start_year=None):
         as_string = _bytes.decode("utf-8")
         params = json.loads(as_string)
     else:
-        with open(Params.params_path) as f:
+        with open(Parameters.params_path) as f:
             params = json.load(f)
 
     if start_year:
@@ -194,10 +194,10 @@ def default_data(metadata=False, start_year=None):
                 if v['cpi_inflated'] is True:
                     if isinstance(new_val, list):
                         for y in range(last_year_for_data, start_year):
-                            new_val = [x * (1.0 + Params._Params__rates[y]) for x in new_val]
+                            new_val = [x * (1.0 + Parameters._Parameters__rates[y]) for x in new_val]
                     else:
                         for y in range(last_year_for_data, start_year):
-                            new_val *= 1.0 + Params._Params__rates[y]
+                            new_val *= 1.0 + Parameters._Parameters__rates[y]
                 #Set the new values
                 v['value'] = [new_val]
 

--- a/taxcalc/parameters.py
+++ b/taxcalc/parameters.py
@@ -6,7 +6,7 @@ from pkg_resources import resource_stream, Requirement
 
 DEFAULT_START_YEAR = 2013
 
-class Parameters(object):
+class Params(object):
 
 
     CUR_PATH = os.path.abspath(os.path.dirname(__file__))
@@ -73,7 +73,7 @@ class Parameters(object):
 
     def update(self, year_mods):
         """
-        Take a dictionary of year: {name:val} mods and set them on this Parameters object.
+        Take a dictionary of year: {name:val} mods and set them on this Params object.
         'year_mods' is a dictionary of year: mods where mods is a dict of key:value pairs
         and key_cpi:Bool pairs. The key_cpi:Bool pairs indicate if the value for 'key'
         should be inflated
@@ -159,15 +159,15 @@ class Parameters(object):
 
 def default_data(metadata=False, start_year=None):
     """ Retreive of default parameters """
-    parampath = Parameters.params_path
+    parampath = Params.params_path
     if not os.path.exists(parampath):
-        path_in_egg = os.path.join("taxcalc", Parameters.PARAM_FILENAME)
+        path_in_egg = os.path.join("taxcalc", Params.PARAM_FILENAME)
         buf = resource_stream(Requirement.parse("taxcalc"), path_in_egg)
         _bytes = buf.read()
         as_string = _bytes.decode("utf-8")
         params = json.loads(as_string)
     else:
-        with open(Parameters.params_path) as f:
+        with open(Params.params_path) as f:
             params = json.load(f)
 
     if start_year:
@@ -194,10 +194,10 @@ def default_data(metadata=False, start_year=None):
                 if v['cpi_inflated'] is True:
                     if isinstance(new_val, list):
                         for y in range(last_year_for_data, start_year):
-                            new_val = [x * (1.0 + Parameters._Parameters__rates[y]) for x in new_val]
+                            new_val = [x * (1.0 + Params._Params__rates[y]) for x in new_val]
                     else:
                         for y in range(last_year_for_data, start_year):
-                            new_val *= 1.0 + Parameters._Parameters__rates[y]
+                            new_val *= 1.0 + Params._Params__rates[y]
                 #Set the new values
                 v['value'] = [new_val]
 

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -54,7 +54,7 @@ def run(puf=True):
 
     # Create a Parameters object
 
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -99,14 +99,14 @@ puf = Records(tax_dta)
 
 def test_make_Calculator():
     # Create a Params object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
     calc = Calculator(params, puf)
 
 
 def test_make_Calculator_deepcopy():
     import copy
     # Create a Params object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
     calc = Calculator(params, puf)
     calc2 = copy.deepcopy(calc)
 
@@ -127,7 +127,7 @@ def test_make_Calculator_files_to_ctor(paramsfile):
 def test_make_Calculator_mods():
 
     # Create a Params object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -139,7 +139,7 @@ def test_make_Calculator_mods():
 def test_make_Calculator_json():
 
     # Create a Params object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -158,7 +158,7 @@ def test_make_Calculator_json():
 def test_make_Calculator_user_mods_as_dict():
 
     # Create a Params object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -187,8 +187,8 @@ def test_make_Calculator_user_mods_with_cpi_flags(paramsfile):
                  "_rt7": [0.396]}}
 
     inf_rates = [irates[1991 + i] for i in range(0, 12)]
-    # Create a Params object
-    params = Params(start_year=1991, inflation_rates=irates)
+    # Create a Parameters object
+    params = Parameters(start_year=1991, inflation_rates=irates)
     calc2 = calculator(params, puf, mods=user_mods)
 
     exp_almdep = expand_array(np.array([7150, 7250, 7400]), inflate=True,
@@ -211,7 +211,7 @@ def test_make_Calculator_empty_params_is_default_params():
 def test_Calculator_attr_access_to_params():
 
     # Create a Parameters object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -232,7 +232,7 @@ def test_Calculator_attr_access_to_params():
 def test_Calculator_create_distribution_table():
 
     # Create a Parameters object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
     # Create a Public Use File object
     puf = Records(tax_dta)
     # Create a Calculator
@@ -247,7 +247,7 @@ def test_Calculator_create_distribution_table():
 def test_Calculator_create_difference_table():
 
     # Create a Parameters object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
     # Create a Public Use File object
     puf = Records(tax_dta)
     # Create a Calculator
@@ -255,7 +255,7 @@ def test_Calculator_create_difference_table():
     calc.calc_all()
 
     # Create a Parameters object
-    params = Params(start_year=1991, inflation_rates=irates)
+    params = Parameters(start_year=1991, inflation_rates=irates)
     # Create a Public Use File object
     puf = Records(tax_dta)
     user_mods = '{"1991": { "_rt7": [0.45] }}'
@@ -271,7 +271,7 @@ def test_diagnostic_table():
           2018:0.024, 2019:0.024}
 
     # Create a Parameters object
-    params = Params(start_year=2008, inflation_rates=irates)
+    params = Parameters(start_year=2008, inflation_rates=irates)
     # Create a Public Use File object
     tax_dta.flpdyr += 17
     puf = Records(tax_dta, weights = weights)

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -133,7 +133,7 @@ def test_make_Calculator_mods():
     puf = Records(tax_dta)
 
     calc2 = calculator(params, puf, _II_em = np.array([4000]), _II_em_cpi=False)
-    assert all(calc2._II_em == np.array([4000]))
+    assert all(calc2.params._II_em == np.array([4000]))
 
 
 def test_make_Calculator_json():
@@ -148,11 +148,11 @@ def test_make_Calculator_json():
                      "_STD_Aged_cpi": false}}"""
 
     calc2 = calculator(params, puf, mods=user_mods, _II_em_cpi=False, _II_em=np.array([4000]))
-    assert calc2.II_em == 4000
-    assert_array_equal(calc2._II_em, np.array([4000]*12))
+    assert calc2.params.II_em == 4000
+    assert_array_equal(calc2.params._II_em, np.array([4000]*12))
     exp_STD_Aged = [[1500, 1250, 1200, 1500, 1500, 1200 ]] * 12
-    assert_array_equal(calc2._STD_Aged, np.array(exp_STD_Aged))
-    assert_array_equal(calc2.STD_Aged, np.array([1500, 1250, 1200, 1500, 1500, 1200 ]))
+    assert_array_equal(calc2.params._STD_Aged, np.array(exp_STD_Aged))
+    assert_array_equal(calc2.params.STD_Aged, np.array([1500, 1250, 1200, 1500, 1500, 1200 ]))
 
 
 def test_make_Calculator_user_mods_as_dict():
@@ -167,10 +167,10 @@ def test_make_Calculator_user_mods_as_dict():
     user_mods[1991]['_II_em'] = [3925, 4000, 4100]
     user_mods[1991]['_II_em_cpi'] = False
     calc2 = calculator(params, puf, mods=user_mods)
-    assert calc2.II_em == 3925
+    assert calc2.params.II_em == 3925
     exp_II_em = [3925, 4000] + [4100] * 10
-    assert_array_equal(calc2._II_em, np.array(exp_II_em))
-    assert_array_equal(calc2.STD_Aged, np.array([1400, 1200]))
+    assert_array_equal(calc2.params._II_em, np.array(exp_II_em))
+    assert_array_equal(calc2.params.STD_Aged, np.array([1400, 1200]))
 
 
 def test_make_Calculator_user_mods_with_cpi_flags(paramsfile):
@@ -197,8 +197,8 @@ def test_make_Calculator_user_mods_with_cpi_flags(paramsfile):
     exp_almsep_values = [40400] + [41050] * 11
     exp_almsep = np.array(exp_almsep_values)
 
-    assert_array_equal(calc2._almdep, exp_almdep)
-    assert_array_equal(calc2._almsep, exp_almsep)
+    assert_array_equal(calc2.params._almdep, exp_almdep)
+    assert_array_equal(calc2.params._almsep, exp_almsep)
 
 
 def test_make_Calculator_empty_params_is_default_params():
@@ -220,29 +220,13 @@ def test_Calculator_attr_access_to_params():
     calc = Calculator(params=params, records=puf)
 
     # Records data
-    assert hasattr(calc, 'c01000')
+    assert hasattr(calc.records, 'c01000')
     # Parameter data
-    assert hasattr(calc, '_AMT_Child_em')
+    assert hasattr(calc.params, '_AMT_Child_em')
     # local attribute
     assert hasattr(calc, 'params')
 
 
-def test_Calculator_set_attr_passes_through():
-
-    # Create a Parameters object
-    params = Params(start_year=1991, inflation_rates=irates)
-    # Create a Public Use File object
-    puf = Records(tax_dta)
-    # Create a Calculator
-    calc = Calculator(params=params, records=puf)
-
-    assert id(calc.e00200) == id(calc.records.e00200)
-    calc.e00200 = calc.e00200 + 100
-    assert id(calc.e00200) == id(calc.records.e00200)
-    assert_array_equal( calc.e00200, calc.records.e00200)
-
-    with pytest.raises(AttributeError):
-        calc.foo == 14
 
 
 def test_Calculator_create_distribution_table():

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -54,13 +54,13 @@ def run(puf=True):
 
     # Create a Parameters object
 
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    params = Params(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
 
     # Create a Calculator
-    calc = Calculator(parameters=params, records=puf)
+    calc = Calculator(params=params, records=puf)
     totaldf = calc.calc_all_test()
 
     # drop duplicates
@@ -98,15 +98,15 @@ def test_sequence():
 puf = Records(tax_dta)
 
 def test_make_Calculator():
-    # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    # Create a Params object
+    params = Params(start_year=1991, inflation_rates=irates)
     calc = Calculator(params, puf)
 
 
 def test_make_Calculator_deepcopy():
     import copy
-    # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    # Create a Params object
+    params = Params(start_year=1991, inflation_rates=irates)
     calc = Calculator(params, puf)
     calc2 = copy.deepcopy(calc)
 
@@ -119,15 +119,15 @@ def test_make_Calculator_from_files(paramsfile):
 
 
 def test_make_Calculator_files_to_ctor(paramsfile):
-    calc = Calculator(parameters=paramsfile.name, records=tax_dta_path,
+    calc = Calculator(params=paramsfile.name, records=tax_dta_path,
                       start_year=1991, inflation_rates=irates)
     assert calc
 
 
 def test_make_Calculator_mods():
 
-    # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    # Create a Params object
+    params = Params(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -138,8 +138,8 @@ def test_make_Calculator_mods():
 
 def test_make_Calculator_json():
 
-    # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    # Create a Params object
+    params = Params(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -157,8 +157,8 @@ def test_make_Calculator_json():
 
 def test_make_Calculator_user_mods_as_dict():
 
-    # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    # Create a Params object
+    params = Params(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
@@ -175,7 +175,7 @@ def test_make_Calculator_user_mods_as_dict():
 
 def test_make_Calculator_user_mods_with_cpi_flags(paramsfile):
 
-    calc = Calculator(parameters=paramsfile.name,
+    calc = Calculator(params=paramsfile.name,
                       records=tax_dta_path, start_year=1991,
                       inflation_rates=irates)
 
@@ -187,8 +187,8 @@ def test_make_Calculator_user_mods_with_cpi_flags(paramsfile):
                  "_rt7": [0.396]}}
 
     inf_rates = [irates[1991 + i] for i in range(0, 12)]
-    # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    # Create a Params object
+    params = Params(start_year=1991, inflation_rates=irates)
     calc2 = calculator(params, puf, mods=user_mods)
 
     exp_almdep = expand_array(np.array([7150, 7250, 7400]), inflate=True,
@@ -211,30 +211,30 @@ def test_make_Calculator_empty_params_is_default_params():
 def test_Calculator_attr_access_to_params():
 
     # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    params = Params(start_year=1991, inflation_rates=irates)
 
     # Create a Public Use File object
     puf = Records(tax_dta)
 
     # Create a Calculator
-    calc = Calculator(parameters=params, records=puf)
+    calc = Calculator(params=params, records=puf)
 
     # Records data
     assert hasattr(calc, 'c01000')
     # Parameter data
     assert hasattr(calc, '_AMT_Child_em')
     # local attribute
-    assert hasattr(calc, 'parameters')
+    assert hasattr(calc, 'params')
 
 
 def test_Calculator_set_attr_passes_through():
 
     # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    params = Params(start_year=1991, inflation_rates=irates)
     # Create a Public Use File object
     puf = Records(tax_dta)
     # Create a Calculator
-    calc = Calculator(parameters=params, records=puf)
+    calc = Calculator(params=params, records=puf)
 
     assert id(calc.e00200) == id(calc.records.e00200)
     calc.e00200 = calc.e00200 + 100
@@ -248,11 +248,11 @@ def test_Calculator_set_attr_passes_through():
 def test_Calculator_create_distribution_table():
 
     # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    params = Params(start_year=1991, inflation_rates=irates)
     # Create a Public Use File object
     puf = Records(tax_dta)
     # Create a Calculator
-    calc = Calculator(parameters=params, records=puf)
+    calc = Calculator(params=params, records=puf)
     calc.calc_all()
 
     t1 = create_distribution_table(calc, groupby="weighted_deciles", result_type = "weighted_sum")
@@ -263,15 +263,15 @@ def test_Calculator_create_distribution_table():
 def test_Calculator_create_difference_table():
 
     # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    params = Params(start_year=1991, inflation_rates=irates)
     # Create a Public Use File object
     puf = Records(tax_dta)
     # Create a Calculator
-    calc = Calculator(parameters=params, records=puf)
+    calc = Calculator(params=params, records=puf)
     calc.calc_all()
 
     # Create a Parameters object
-    params = Parameters(start_year=1991, inflation_rates=irates)
+    params = Params(start_year=1991, inflation_rates=irates)
     # Create a Public Use File object
     puf = Records(tax_dta)
     user_mods = '{"1991": { "_rt7": [0.45] }}'
@@ -287,13 +287,13 @@ def test_diagnostic_table():
           2018:0.024, 2019:0.024}
 
     # Create a Parameters object
-    params = Parameters(start_year=2008, inflation_rates=irates)
+    params = Params(start_year=2008, inflation_rates=irates)
     # Create a Public Use File object
     tax_dta.flpdyr += 17
     puf = Records(tax_dta, weights = weights)
     # Create a Calculator
     
-    calc = Calculator(parameters=params, records=puf, sync_years=False)
+    calc = Calculator(params=params, records=puf, sync_years=False)
 
     calc.diagnostic_table()
 

--- a/taxcalc/tests/test_decorators.py
+++ b/taxcalc/tests/test_decorators.py
@@ -107,7 +107,7 @@ def test_create_apply_function_string():
     assert ans == exp
 
 
-def test_create_apply_function_string_with_parameters():
+def test_create_apply_function_string_with_params():
     ans = create_apply_function_string(['a', 'b', 'c'], ['d', 'e'], ['d'])
     exp = ("def ap_func(x_0,x_1,x_2,x_3,x_4):\n"
            "  for i in range(len(x_0)):\n"

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -36,14 +36,14 @@ def paramsfile():
     os.remove(f.name)
 
 
-def test_create_parameters():
-    p = Parameters()
+def test_create_params():
+    p = Params()
     assert p
 
 
-def test_create_parameters_from_file(paramsfile):
-    p = Parameters.from_file(paramsfile.name)
-    irates = Parameters._Parameters__rates
+def test_create_params_from_file(paramsfile):
+    p = Params.from_file(paramsfile.name)
+    irates = Params._Params__rates
     inf_rates = [irates[2013 + i] for i in range(0, 12)]
 
     assert_array_equal(p._almdep,
@@ -60,33 +60,33 @@ def test_create_parameters_from_file(paramsfile):
                                     inflation_rates=inf_rates, num_years=12))
 
 
-def test_parameters_get_default(paramsfile):
+def test_params_get_default(paramsfile):
     paramdata = taxcalc.parameters.default_data()
     assert paramdata['_CDCC_ps'] == [15000]
 
 
-def test_update_Parameters_raises_on_no_year(paramsfile):
-    p = Parameters.from_file(paramsfile.name)
+def test_update_Params_raises_on_no_year(paramsfile):
+    p = Params.from_file(paramsfile.name)
     user_mods = { "_STD_Aged": [[1400, 1200]] }
     with pytest.raises(ValueError):
         p.update(user_mods)
 
 
-def test_update_Parameters_update_current_year():
-    p = Parameters(start_year=2013)
+def test_update_Params_update_current_year():
+    p = Params(start_year=2013)
     user_mods = {2013: { "_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]] }}
     p.update(user_mods)
     assert_array_equal(p.STD_Aged, np.array([1400, 1100, 1100, 1400, 1400, 1199]))
 
 
-def test_update_Parameters_raises_on_future_year():
-    p = Parameters(start_year=2013)
+def test_update_Params_raises_on_future_year():
+    p = Params(start_year=2013)
     with pytest.raises(ValueError):
         user_mods = {2015: { "_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]] }}
         p.update(user_mods)
 
-def test_update_Parameters_maintains_default_cpi_flags():
-    p = Parameters(start_year=2013)
+def test_update_Params_maintains_default_cpi_flags():
+    p = Params(start_year=2013)
     p.increment_year()
     p.increment_year()
     user_mods = {2015: { "_II_em": [4300]}}
@@ -97,16 +97,16 @@ def test_update_Parameters_maintains_default_cpi_flags():
     assert p.II_em != 4300
 
 
-def test_update_Parameters_increment_until_mod_year():
-    p = Parameters(start_year=2013)
+def test_update_Params_increment_until_mod_year():
+    p = Params(start_year=2013)
     p.increment_year()
     p.increment_year()
     user_mods = {2015: { "_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]] }}
     p.update(user_mods)
     assert_array_equal(p.STD_Aged, np.array([1400, 1100, 1100, 1400, 1400, 1199]))
 
-def test_increment_Parameters_increment_and_then_update():
-    p = Parameters(start_year=2013)
+def test_increment_Params_increment_and_then_update():
+    p = Params(start_year=2013)
     p.increment_year()
     p.increment_year()
     user_mods = {2015: { "_II_em": [4400], "_II_em_cpi": True}}
@@ -114,7 +114,7 @@ def test_increment_Parameters_increment_and_then_update():
     assert_array_equal(p._II_em[:3], np.array([3900, 3950, 4400]))
     assert p.II_em == 4400
 
-def test_parameters_get_default_start_year():
+def test_params_get_default_start_year():
     paramdata = taxcalc.parameters.default_data(start_year=2015, metadata=True)
     #1D data, has 2015 values
     meta_II_em = paramdata['_II_em']
@@ -133,7 +133,7 @@ def test_parameters_get_default_start_year():
     assert meta_amt_thd_marrieds['start_year'] == 2015
     assert meta_amt_thd_marrieds['row_label'] == ["2015"]
     #Take the 2014 rate and multiply by inflation for that year
-    assert meta_amt_thd_marrieds['value'] == [41050 * (1.0 + Parameters._Parameters__rates[2014])]
+    assert meta_amt_thd_marrieds['value'] == [41050 * (1.0 + Params._Params__rates[2014])]
 
     #1D data, doesn't have 2015 values, is not CPI inflated
     meta_kt_c_age = paramdata['_KT_c_Age']

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -36,14 +36,14 @@ def paramsfile():
     os.remove(f.name)
 
 
-def test_create_params():
-    p = Params()
+def test_create_parameters():
+    p = Parameters()
     assert p
 
 
-def test_create_params_from_file(paramsfile):
-    p = Params.from_file(paramsfile.name)
-    irates = Params._Params__rates
+def test_create_parameters_from_file(paramsfile):
+    p = Parameters.from_file(paramsfile.name)
+    irates = Parameters._Parameters__rates
     inf_rates = [irates[2013 + i] for i in range(0, 12)]
 
     assert_array_equal(p._almdep,
@@ -60,33 +60,33 @@ def test_create_params_from_file(paramsfile):
                                     inflation_rates=inf_rates, num_years=12))
 
 
-def test_params_get_default(paramsfile):
+def test_parameters_get_default(paramsfile):
     paramdata = taxcalc.parameters.default_data()
     assert paramdata['_CDCC_ps'] == [15000]
 
 
-def test_update_Params_raises_on_no_year(paramsfile):
-    p = Params.from_file(paramsfile.name)
+def test_update_Parameters_raises_on_no_year(paramsfile):
+    p = Parameters.from_file(paramsfile.name)
     user_mods = { "_STD_Aged": [[1400, 1200]] }
     with pytest.raises(ValueError):
         p.update(user_mods)
 
 
-def test_update_Params_update_current_year():
-    p = Params(start_year=2013)
+def test_update_Parameters_update_current_year():
+    p = Parameters(start_year=2013)
     user_mods = {2013: { "_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]] }}
     p.update(user_mods)
     assert_array_equal(p.STD_Aged, np.array([1400, 1100, 1100, 1400, 1400, 1199]))
 
 
-def test_update_Params_raises_on_future_year():
-    p = Params(start_year=2013)
+def test_update_Parameters_raises_on_future_year():
+    p = Parameters(start_year=2013)
     with pytest.raises(ValueError):
         user_mods = {2015: { "_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]] }}
         p.update(user_mods)
 
-def test_update_Params_maintains_default_cpi_flags():
-    p = Params(start_year=2013)
+def test_update_Parameters_maintains_default_cpi_flags():
+    p = Parameters(start_year=2013)
     p.increment_year()
     p.increment_year()
     user_mods = {2015: { "_II_em": [4300]}}
@@ -97,16 +97,16 @@ def test_update_Params_maintains_default_cpi_flags():
     assert p.II_em != 4300
 
 
-def test_update_Params_increment_until_mod_year():
-    p = Params(start_year=2013)
+def test_update_Parameters_increment_until_mod_year():
+    p = Parameters(start_year=2013)
     p.increment_year()
     p.increment_year()
     user_mods = {2015: { "_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]] }}
     p.update(user_mods)
     assert_array_equal(p.STD_Aged, np.array([1400, 1100, 1100, 1400, 1400, 1199]))
 
-def test_increment_Params_increment_and_then_update():
-    p = Params(start_year=2013)
+def test_increment_Parameters_increment_and_then_update():
+    p = Parameters(start_year=2013)
     p.increment_year()
     p.increment_year()
     user_mods = {2015: { "_II_em": [4400], "_II_em_cpi": True}}
@@ -114,7 +114,7 @@ def test_increment_Params_increment_and_then_update():
     assert_array_equal(p._II_em[:3], np.array([3900, 3950, 4400]))
     assert p.II_em == 4400
 
-def test_params_get_default_start_year():
+def test_parameters_get_default_start_year():
     paramdata = taxcalc.parameters.default_data(start_year=2015, metadata=True)
     #1D data, has 2015 values
     meta_II_em = paramdata['_II_em']
@@ -133,7 +133,7 @@ def test_params_get_default_start_year():
     assert meta_amt_thd_marrieds['start_year'] == 2015
     assert meta_amt_thd_marrieds['row_label'] == ["2015"]
     #Take the 2014 rate and multiply by inflation for that year
-    assert meta_amt_thd_marrieds['value'] == [41050 * (1.0 + Params._Params__rates[2014])]
+    assert meta_amt_thd_marrieds['value'] == [41050 * (1.0 + Parameters._Parameters__rates[2014])]
 
     #1D data, doesn't have 2015 values, is not CPI inflated
     meta_kt_c_age = paramdata['_KT_c_Age']

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -128,8 +128,8 @@ def test_create_tables():
     #Create a Public Use File object
     cur_path = os.path.abspath(os.path.dirname(__file__))
     tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
-    # Create a default Params object
-    params1 = Params(start_year=1991, inflation_rates=irates)
+    # Create a default Parameters object
+    params1 = Parameters(start_year=1991, inflation_rates=irates)
     records1 = Records(tax_dta_path)
     # Create a Calculator
     calc1 = Calculator(params=params1, records=records1)
@@ -137,7 +137,7 @@ def test_create_tables():
 
     # User specified Plans
     user_mods = '{"1991": {"_II_rt4": [0.56]}}'
-    params2 = Params(start_year=1991, inflation_rates=irates)
+    params2 = Parameters(start_year=1991, inflation_rates=irates)
     records2 = Records(tax_dta_path)
     # Create a Calculator
     calc2 = calculator(params=params2, records=records2, mods=user_mods)
@@ -308,7 +308,7 @@ def test_dist_table_sum_row():
     cur_path = os.path.abspath(os.path.dirname(__file__))
     tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
     # Create a default Parameters object
-    params1 = Params(start_year=1991, inflation_rates=irates)
+    params1 = Parameters(start_year=1991, inflation_rates=irates)
     records1 = Records(tax_dta_path)
     # Create a Calculator
     calc1 = Calculator(params=params1, records=records1)
@@ -327,7 +327,7 @@ def test_diff_table_sum_row():
     cur_path = os.path.abspath(os.path.dirname(__file__))
     tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
     # Create a default Parameters object
-    params1 = Params(start_year=1991, inflation_rates=irates)
+    params1 = Parameters(start_year=1991, inflation_rates=irates)
     records1 = Records(tax_dta_path)
     # Create a Calculator
     calc1 = Calculator(params=params1, records=records1)
@@ -335,7 +335,7 @@ def test_diff_table_sum_row():
 
     # User specified Plans
     user_mods = '{"1991": {"_II_rt4": [0.56]}}'
-    params2 = Params(start_year=1991, inflation_rates=irates)
+    params2 = Parameters(start_year=1991, inflation_rates=irates)
     records2 = Records(tax_dta_path)
     # Create a Calculator
     calc2 = calculator(params=params2, records=records2, mods=user_mods)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -128,19 +128,19 @@ def test_create_tables():
     #Create a Public Use File object
     cur_path = os.path.abspath(os.path.dirname(__file__))
     tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
-    # Create a default Parameters object
-    params1 = Parameters(start_year=1991, inflation_rates=irates)
+    # Create a default Params object
+    params1 = Params(start_year=1991, inflation_rates=irates)
     records1 = Records(tax_dta_path)
     # Create a Calculator
-    calc1 = Calculator(parameters=params1, records=records1)
+    calc1 = Calculator(params=params1, records=records1)
     calc1.calc_all()
 
     # User specified Plans
     user_mods = '{"1991": {"_II_rt4": [0.56]}}'
-    params2 = Parameters(start_year=1991, inflation_rates=irates)
+    params2 = Params(start_year=1991, inflation_rates=irates)
     records2 = Records(tax_dta_path)
     # Create a Calculator
-    calc2 = calculator(parameters=params2, records=records2, mods=user_mods)
+    calc2 = calculator(params=params2, records=records2, mods=user_mods)
 
     calc2.calc_all()
 
@@ -308,10 +308,10 @@ def test_dist_table_sum_row():
     cur_path = os.path.abspath(os.path.dirname(__file__))
     tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
     # Create a default Parameters object
-    params1 = Parameters(start_year=1991, inflation_rates=irates)
+    params1 = Params(start_year=1991, inflation_rates=irates)
     records1 = Records(tax_dta_path)
     # Create a Calculator
-    calc1 = Calculator(parameters=params1, records=records1)
+    calc1 = Calculator(params=params1, records=records1)
     calc1.calc_all()
 
     t1 = create_distribution_table(calc1, groupby="small_agi_bins", result_type="weighted_sum")
@@ -327,18 +327,18 @@ def test_diff_table_sum_row():
     cur_path = os.path.abspath(os.path.dirname(__file__))
     tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
     # Create a default Parameters object
-    params1 = Parameters(start_year=1991, inflation_rates=irates)
+    params1 = Params(start_year=1991, inflation_rates=irates)
     records1 = Records(tax_dta_path)
     # Create a Calculator
-    calc1 = Calculator(parameters=params1, records=records1)
+    calc1 = Calculator(params=params1, records=records1)
     calc1.calc_all()
 
     # User specified Plans
     user_mods = '{"1991": {"_II_rt4": [0.56]}}'
-    params2 = Parameters(start_year=1991, inflation_rates=irates)
+    params2 = Params(start_year=1991, inflation_rates=irates)
     records2 = Records(tax_dta_path)
     # Create a Calculator
-    calc2 = calculator(parameters=params2, records=records2, mods=user_mods)
+    calc2 = calculator(params=params2, records=records2, mods=user_mods)
     calc2.calc_all()
 
     tdiff1 = create_difference_table(calc1, calc2, groupby="small_agi_bins")

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -365,7 +365,7 @@ def get_sums(df, na=False):
 
 
 def results(c):
-    outputs = [getattr(c, col) for col in STATS_COLUMNS]
+    outputs = [getattr(c.records, col) for col in STATS_COLUMNS]
     return DataFrame(data=np.column_stack(outputs), columns=STATS_COLUMNS)
 
 


### PR DESCRIPTION
I am wondering what you all think about removing the Calculator's attribute access to params and records. This PR demonstrates what that would look like. 

My sense from observing new users is that having the API rely on the Calculator's attribute access to params and records makes it more difficult for people to grasp the structure of the calculator and has been a point of confusion for our new users/contributors. 

For example, rather than writing  `calc.II_em` to access the personal exemption amount, it would be more expressive if the user were to write `calc.params.II_em`. 

This would also simplify our codebase considerably. 

A penalty is that the API will be more verbose, and the user will have to remember which data are tax law parameters (params) and which data are tax unit characteristics (records) when using the API. That said, nothing will change in functions.py, where the bulk of the tax logic is -- we won't have to use this notation there. Furthermore, our encouragement for the user to think of the data as belonging to either params or records may be educational.  

In recognition that there would be more to type under this scheme, I renamed `parameters` to `params`. 

  