### PR TITLE
State and Local Deduction haircut

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -389,7 +389,7 @@ def TaxGains(e00650, c04800, e01000, c23650, e23250, e01100, e58990,
     else:
         _hasgain = 0.
 
-    if _taxinc > 0. and _hasgain == 1.:
+    if _hasgain == 1.:
         #if/else 1
         _dwks5 = max(0., e58990 - e58980)
         c24505 = max(0., c00650 - _dwks5)

--- a/test.py
+++ b/test.py
@@ -34,7 +34,7 @@ def run(puf=True):
 
     # Create a Public Use File object
 
-    tax_dta = pd.read_csv("puf.csv")
+    tax_dta = pd.read_csv("/Users/Amy/Documents/puf.csv")
 
     blowup_factors = "./taxcalc/StageIFactors.csv"
     weights = "./taxcalc/WEIGHTS.csv"
@@ -43,6 +43,12 @@ def run(puf=True):
 
     # Create a Calculator
     calc = Calculator(parameters=params, records=puf)
+    #calc.records.e18400 = calc.records.e18400 - calc.records.e18400
+    #calc.records.e18425 = calc.records.e18425 - calc.records.e18425
+    #calc.records.e18450 = calc.records.e18450 - calc.records.e18450
+    #calc.records.e18500 = calc.records.e18500 - calc.records.e18500
+    #calc.records.e18800 = calc.records.e18800 - calc.records.e18800
+    #calc.records.e18900 = calc.records.e18900 - calc.records.e18900
     totaldf = calc.calc_all_test()
 
     # drop duplicates

--- a/test.py
+++ b/test.py
@@ -34,7 +34,7 @@ def run(puf=True):
 
     # Create a Public Use File object
 
-    tax_dta = pd.read_csv("/Users/Amy/Documents/puf.csv")
+    tax_dta = pd.read_csv("puf.csv")
 
     blowup_factors = "./taxcalc/StageIFactors.csv"
     weights = "./taxcalc/WEIGHTS.csv"
@@ -43,12 +43,6 @@ def run(puf=True):
 
     # Create a Calculator
     calc = Calculator(parameters=params, records=puf)
-    #calc.records.e18400 = calc.records.e18400 - calc.records.e18400
-    #calc.records.e18425 = calc.records.e18425 - calc.records.e18425
-    #calc.records.e18450 = calc.records.e18450 - calc.records.e18450
-    #calc.records.e18500 = calc.records.e18500 - calc.records.e18500
-    #calc.records.e18800 = calc.records.e18800 - calc.records.e18800
-    #calc.records.e18900 = calc.records.e18900 - calc.records.e18900
     totaldf = calc.calc_all_test()
 
     # drop duplicates


### PR DESCRIPTION
There are two issues involved in the decreased tax as a result of state and local deduction haircut. We identified the first one, in regular cap gain function, as a bug and fixed it in this PR. The second one needs further confirmation from experiments.

The first part comes from an  if-condition in TaxGain function. Previously, we only calculate cap gain for regular tax if taxable income (_taxinc) is positive. Otherwise we set it to zero. This will give many records a jump in cap gain after we apply the haircut, which will increase cap gain for AMT, decrease total AMT and ultimately reduce ospc tax. The commits in this PR removed this if-condition.

The second part of the issue might be resulted from improper design of IRS forms but needs more confirmation. Currently many people choose to itemize their deductions for regular tax because their could deduct more than standard deduction. But they might end up paying AMT, which adds back itemized deduction in the tax base, and get penalized for choosing this higher itemized deduction. In other words, they should have chosen standard deduction even it's smaller than itemized deduction, because standard deduction is not included in AMT base and these taxpayers would therefore have a lower tax liability. This might explain why many taxpayers have lower OSPC tax in the haircut scenario. Because of the haircut, they switched from itemized deduction to standard deduction, reduced their AMT tax base and ended up paying less tax. @MattHJensen is about to do more analysis on this group of tax payers to confirm our hypothesis.

Here're some useful ipython notebook commands for testing:
1) To get the record 100 IDs of taxpayers with lower OSPC tax `calc2.records.RECID[(calc2.records._ospctax-calc1.records._ospctax)<-0.01][:100]`
2) To retrive taxpayer informations from notebook `calc2.records.c00100[calc2.records.RECID==12345]`

