### PR TITLE
Revisions to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ The second way is to access the Tax Calculator through our web
 application, [TaxBrain](http://www.ospc.org/).  Do this by emailing
 [Matt Jensen](mailto:matt.jensen@aei.org) about becoming a TaxBrain
 beta tester.
+
+Conda Package for Advanced Anaconda Users
+=========================================
+
+Conda taxcalc packages are created for every release of the Tax
+Calculator.  We use them to install taxcalc on Amazon Web Services
+(AWS) instances that run the TaxBrain web application.  You can get
+the latest release of the taxcalc package to run on your computer via
+the command `conda install -c ospc taxcalc`.  Note that this package
+does not include a micro data set that represents the US population.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,41 @@
 Tax Calculator
-=======
-The Tax Calculator is a calculator for the US federal individual income tax system. In conjunction with micro data that represents US taxpayer characteristics and a set of behavioral assumptions, we use the Tax Calculator to conduct revenue estimation and distributional analyses of tax policies. 
+==============
 
-Documentation for the Tax calculator is available at http://taxcalc.readthedocs.org/en/latest/.
+The Tax Calculator simulates the US federal individual income tax
+system.  In conjunction with micro data that represent the US
+population and a set of behavioral assumptions, the Tax Calculator can
+be used to conduct revenue scoring and distributional analyses of tax
+policies.  The Tax Calculator is written in Python, an interpreted
+language that can execute on Windows, Mac, or Linux.
 
 About OSPC
-=======
-The Open-Source Policy Center (OSPC) seeks to make policy analysis more transparent, trustworthy, and collaborative by harnessing open-source methods to build cutting-edge economic models. 
+==========
+
+The Open Source Policy Center (OSPC) seeks to make policy analysis
+more transparent, trustworthy, and collaborative by harnessing
+open-source methods to build cutting-edge economic models.
 
 Disclaimer
-========
-The Tax-Calculator is currently under development. Therefore, there is NO GUARANTEE OF ACCURACY. THE CODE SHOULD NOT CURRENTLY BE USED FOR PUBLICATIONS, JOURNAL ARTICLES, OR RESEARCH PURPOSES. DO NOT CITE. Furthermore, users should be forewarned that the interface could change significantly, and the implementation is subject to wild change. The code is currently available for testing purposes only.
+==========
 
+The Tax Calculator is currently under development.  Users should be
+forewarned that the taxcalc API (application programming interface)
+could change significantly, and the implementation is subject to wild
+change.  Therefore, there is NO GUARANTEE OF ACCURACY. THE CODE SHOULD
+NOT CURRENTLY BE USED FOR PUBLICATIONS, JOURNAL ARTICLES, OR RESEARCH
+PURPOSES.  The source code is currently available for testing purposes
+only.
 
-Installation
-=======
-The taxcalc package is installable via `python setup.py install`. We currently test against Python 2.7 and 3.4. You can install the latest conda package via
+Getting Started
+===============
 
-```
-conda install -c ospc taxcalc
-```
+At the moment there are two ways to start using the Tax Calculator.
 
-which will grab the latest taxcalc package from binstar.org. Currently, we host Python 2.7 and 3.4 packages for Linux, OS X, and Windows.
+The first way is install the Tax Calculator on your computer.  Do this
+by following the instructions in our [Contributor
+Guide](http://taxcalc.readthedocs.org/en/latest/contributor_guide.html).
 
-For contributors, the conda recipe is located in the `conda.recipe` directory. You can build the conda package via the `conda build` command:
-
-```
-conda build --python 3.4 conda.recipe/
-```
-
-To learn more about the conda package manager, go to conda.pydata.org.
-
+The second way is to access the Tax Calculator through our web
+application, [TaxBrain](http://www.ospc.org/).  Do this by emailing
+[Matt Jensen](mailto:matt.jensen@aei.org) about becoming a TaxBrain
+beta tester.


### PR DESCRIPTION
Edit file so that lines are less than 80 characters long and
so that old installation instructions are replaced with two
ways to get started with the Tax Calculator.  Also, hide
URL and email address behind clickable text.