### PR TITLE
Edit docstrings in taxcalc/*.py files to eliminate Sphinx warnings.

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1328,10 +1328,9 @@ def LLC(e87530, LLC_Expense_c, e87526, e87522, e87524, e87528, c87540, c87550, p
         e87530 : Total expense
     
     
-    Returns:
-    --------
-    c87550
-        Nonrefundable Education Credit 
+    Returns
+    -------
+    c87550 : Nonrefundable Education Credit 
     
     """
 

--- a/taxcalc/utils.py
+++ b/taxcalc/utils.py
@@ -435,10 +435,10 @@ def create_distribution_table(calc, groupby, result_type,
     calc : the Calculator object
     groupby : String object
         options for input: 'weighted_deciles', 'small_income_bins',
-                           'large_income_bins', 'webapp_income_bins'
+        'large_income_bins', 'webapp_income_bins';
         determines how the columns in the resulting DataFrame are sorted
-    result_type: String object
-        options for input: 'weighted_sum' or 'weighted_avg'
+    result_type : String object
+        options for input: 'weighted_sum' or 'weighted_avg';
         determines how the data should be maniuplated
 
     Notes


### PR DESCRIPTION
Minimal docstring edits to eliminate warnings and to correct incorrectly generated documentation.
No changes in taxcalc code.