### PR TITLE
updated min sphinx version pip-requirement and pkg import

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -9,5 +9,4 @@ six
 toolz
 
 # for ReadTheDocs
-sphinx
-sphinxcontrib-napoleon==0.2.11
+sphinx>=1.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath('../..'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'sphinx.ext.pngmath',
     'sphinx.ext.viewcode',
 ]


### PR DESCRIPTION
As of Sphinx version 1.3, the napoleon package is included by default in its extensions. (no need to pip install sphinxcontrib-napoleon anymore for local development)

RTD was pulling the latest sphinx, which has a slightly different import statement. Setting the requirement to use at least Sphinx 1.3 will keep this fixed moving forward. 