### PR TITLE
Correct Calculator class constructor call in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,54 +1,38 @@
+""" Test program for Calculator class logic that uses 'puf.csv' records and
+writes results to the 'results_puf.csv' file.
+
+PYLINT USAGE: pylint test.py
 """
-Testing file for calculate.py
-"""
-
-from pandas import DataFrame, concat
-from taxcalc.calculate import *
-from taxcalc.records import *
-from taxcalc.parameters import *
-import taxcalc.parameters as parameters
-#from timer.timed_calculate import *
+import pandas as pd
+from taxcalc.parameters import Parameters
+from taxcalc.records import Records
+from taxcalc.calculate import Calculator
 
 
-def to_csv(fname, df):
+def run():
+    """ Run each function defined in Calculator.calc_all_test method using
+    'puf.csv' input and writing ouput to a CSV file named 'results_puf.csv'.
     """
-    Save this dataframe to a CSV file with name 'fname' and containing
-    a header with the column names of the dataframe.
-    """
-    df.to_csv(fname, float_format= '%1.3f', sep=',', header=True, index=False)
+    # create a Parameters object containing current-law policy (clp) parameters
+    clp = Parameters()
 
-
-
-def run(puf=True):
-    """
-    Run each function defined in calculate.py, saving the ouput to a CSV file.
-    'puf' set to True by default, to use the 'puf2.csv' as an input
-    
-    For functions returning an additional non-global variable in addition
-    to the DataFrame to be printed, one line saves the dataFrame to be printed 
-    first, and then saves the variable to be used by a following function second. 
-    """
-
-    # Create a Parameters object
-    params = Parameters()
-
-    # Create a Public Use File object
-
-    tax_dta = pd.read_csv("puf.csv")
-
-    blowup_factors = "./taxcalc/StageIFactors.csv"
-    weights = "./taxcalc/WEIGHTS.csv"
-
+    # create a Records object (puf) containing puf.csv input records
+    tax_dta = pd.read_csv('puf.csv')
+    blowup_factors = './taxcalc/StageIFactors.csv'
+    weights = './taxcalc/WEIGHTS.csv'
     puf = Records(tax_dta, blowup_factors, weights)
 
-    # Create a Calculator
-    calc = Calculator(parameters=params, records=puf)
-    totaldf = calc.calc_all_test()
+    # create a Calculator object using clp params and puf records
+    calc = Calculator(params=clp, records=puf)
 
-    # drop duplicates
-    totaldf = totaldf.T.groupby(level=0).first().T
+    # save calculated test results in output dataframe (odf)
+    odf = calc.calc_all_test()
+    odf = odf.T.groupby(level=0).first().T
 
-    to_csv("results_puf.csv", totaldf)
+    # write test output to csv file named 'results_puf.csv'
+    odf.to_csv('results_puf.csv', float_format='%1.3f',
+               sep=',', header=True, index=False)
+
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
Also, make other non-substantive changes to eliminate pylint warnings.
All these changes leave the results_puf.csv output file produced by the
test.py program unchanged.