### PR TITLE
Change html_theme to 'classic' to fix Sphinx 1.3 theme warning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -127,7 +127,7 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This change was recommended by @jlyons871.