### PR TITLE
Various fixes on tests

### DIFF
--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -117,16 +117,6 @@ def test_make_Calculator_deepcopy():
     calc2 = copy.deepcopy(calc)
 
 
-def test_make_Calculator_from_files(paramsfile):
-    with open(paramsfile.name) as pfile:
-        params = json.load(pfile)
-    ppo = Parameters(parameter_dict=params, start_year=1991,
-                     num_years=len(irates), inflation_rates=irates)
-    calc = Calculator(params=ppo, records=tax_dta_path,
-                      start_year=1991, inflation_rates=irates)
-    assert calc
-
-
 def test_make_Calculator_files_to_ctor(paramsfile):
     with open(paramsfile.name) as pfile:
         params = json.load(pfile)
@@ -255,11 +245,10 @@ def test_make_Calculator_user_mods_with_cpi_flags(paramsfile):
     assert_array_equal(act_almsep, exp_almsep)
 
 
-def test_make_Calculator_empty_params_is_default_params():
-    ppo = Parameters()
+def test_make_Calculator_raises_on_no_params():
     rec = Records(tax_dta, start_year=2013)
-    calc = Calculator(params=ppo, records=rec)
-    assert calc
+    with pytest.raises(ValueError):
+        calc = Calculator(records=rec)
 
 
 def test_Calculator_attr_access_to_params():

--- a/taxcalc/tests/test_parameters.py
+++ b/taxcalc/tests/test_parameters.py
@@ -367,7 +367,7 @@ def test_parameters_get_default():
     assert paramdata['_CDCC_ps'] == [15000]
 
 
-def test_reform_with_no_year():
+def test_implement_reform_Parameters_raises_on_no_year():
     reform = {"_STD_Aged": [[1400, 1200]]}
     ppo = Parameters()
     with pytest.raises(ValueError):
@@ -382,7 +382,7 @@ def test_Parameters_reform_in_start_year():
                        np.array([1400, 1100, 1100, 1400, 1400, 1199]))
 
 
-def test_Parameters_reform_before_start_year():
+def test_implement_reform_Parameters_raises_on_future_year():
     ppo = Parameters(start_year=2013)
     with pytest.raises(ValueError):
         reform = {2010: {"_STD_Aged": [[1400, 1100, 1100, 1400, 1400, 1199]]}}


### PR DESCRIPTION
- test that assert the raise of an Exception contain 'raise' in name
- remove 'test_make_Calculator_from_files' since it is identical to
  following test. There is no longer a 'from_files' class method
  so the test should have been removed.