### PR TITLE
Implement itemized deduction benefit surtax

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -286,7 +286,7 @@ class Calculator(object):
 
             # nonrefuncable credits
             nonrefundable = (calc.records.c07100 * calc.records.s006).sum()
-            
+
             # Misc. Surtax
             surtax = (calc.records._surtax * calc.records.s006).sum()
 

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -134,7 +134,7 @@ class Calculator(object):
         DEITC(self.params, self.records)
         OSPC_TAX(self.params, self.records)
         ExpandIncome(self.params, self.records)
-    
+
     def calc_all(self):
         self.calc_one_year()
         BenefitCap(self)

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -137,7 +137,7 @@ class Calculator(object):
 
     def calc_all(self):
         self.calc_one_year()
-        BenefitCap(self)
+        BenefitSurtax(self)
 
     def calc_all_test(self):
         all_dfs = []
@@ -286,6 +286,9 @@ class Calculator(object):
 
             # nonrefuncable credits
             nonrefundable = (calc.records.c07100 * calc.records.s006).sum()
+            
+            # Misc. Surtax
+            surtax = (calc.records._surtax * calc.records.s006).sum()
 
             # ospc_tax
             revenue1 = (calc.records._ospctax * calc.records.s006).sum()
@@ -300,6 +303,7 @@ class Calculator(object):
                           tax_bf_credits / math.pow(10, 9),
                           refundable / math.pow(10, 9),
                           nonrefundable / math.pow(10, 9),
+                          surtax / math.pow(10, 9),
                           revenue1 / math.pow(10, 9)])
             calc.increment_year()
 
@@ -313,6 +317,7 @@ class Calculator(object):
                         "AMT number (#m)", "Tax before credits ($b)",
                         "refundable credits ($b)",
                         "nonrefundable credits ($b)",
+                        "Misc. Surtax ($b)",
                         "ospctax ($b)"])
         df = df.transpose()
         pd.options.display.float_format = '{:8,.1f}'.format

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -384,16 +384,19 @@ class Calculator(object):
             nonrefundable = (calc.records.c07100 * calc.records.s006).sum()
 
             # ospc_tax
-            tax_diff = np.where(calc.records._ospctax - base_calc.records._ospctax > 0,
-                                calc.records._ospctax - base_calc.records._ospctax, 0)
+            tax_diff = np.where(calc.records._ospctax -
+                                base_calc.records._ospctax > 0,
+                                calc.records._ospctax -
+                                base_calc.records._ospctax,
+                                0)
             cap = calc.params.ID_DeductionBenefit_crt * calc.records.c00100
-            
+
             if calc.params.ID_DeductionBenefit_crt != 0:
                 calc.records._ospctax = np.where(tax_diff < cap,
-                                                 tax_diff + calc.records._ospctax,
+                                                 tax_diff +
+                                                 calc.records._ospctax,
                                                  cap + calc.records._ospctax)
-            
-            
+
             revenue1 = (calc.records._ospctax * calc.records.s006).sum()
 
             table.append([returns / math.pow(10, 6), agi / math.pow(10, 9),

--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -103,7 +103,7 @@ class Calculator(object):
     def records(self):
         return self._records
 
-    def calc_all(self):
+    def calc_one_year(self):
         FilingStatus(self.params, self.records)
         Adj(self.params, self.records)
         CapGains(self.params, self.records)
@@ -134,6 +134,10 @@ class Calculator(object):
         DEITC(self.params, self.records)
         OSPC_TAX(self.params, self.records)
         ExpandIncome(self.params, self.records)
+    
+    def calc_all(self):
+        self.calc_one_year()
+        BenefitCap(self)
 
     def calc_all_test(self):
         all_dfs = []
@@ -298,120 +302,6 @@ class Calculator(object):
                           nonrefundable / math.pow(10, 9),
                           revenue1 / math.pow(10, 9)])
             calc.increment_year()
-
-        df = DataFrame(table, row_years,
-                       ["Returns (#m)", "AGI ($b)", "Itemizers (#m)",
-                        "Itemized Deduction ($b)",
-                        "Standard Deduction Filers (#m)",
-                        "Standard Deduction ($b)", "Personal Exemption ($b)",
-                        "Taxable income ($b)", "Regular Tax ($b)",
-                        "AMT income ($b)", "AMT amount ($b)",
-                        "AMT number (#m)", "Tax before credits ($b)",
-                        "refundable credits ($b)",
-                        "nonrefundable credits ($b)",
-                        "ospctax ($b)"])
-        df = df.transpose()
-        pd.options.display.float_format = '{:8,.1f}'.format
-
-        return df
-
-    def diagnostic_table_special_reform(self, base_calc, num_years=5):
-        table = []
-        row_years = []
-        calc = copy.deepcopy(self)
-        base_calc = copy.deepcopy(base_calc)
-
-        for i in range(0, num_years):
-            calc.calc_all()
-            base_calc.calc_all()
-
-            row_years.append(calc.params._current_year)
-
-            # totoal number of records
-            returns = calc.records.s006.sum()
-
-            # AGI
-            agi = (calc.records.c00100 * calc.records.s006).sum()
-
-            # number of itemizers
-            ID1 = calc.records.c04470 * calc.records.s006
-            STD1 = calc.records._standard * calc.records.s006
-            deduction = np.maximum(calc.records.c04470, calc.records._standard)
-
-            # S TD1 = (calc.c04100 + calc.c04200)*calc.s006
-            NumItemizer1 = (calc.records.s006[(calc.records.c04470 > 0) *
-                            (calc.records.c00100 > 0)].sum())
-
-            # itemized deduction
-            ID = ID1[calc.records.c04470 > 0].sum()
-
-            NumSTD = calc.records.s006[(calc.records._standard > 0) *
-                                       (calc.records.c00100 > 0)].sum()
-            # standard deduction
-            STD = STD1[(calc.records._standard > 0) *
-                       (calc.records.c00100 > 0)].sum()
-
-            # personal exemption
-            PE = (calc.records.c04600 *
-                  calc.records.s006)[calc.records.c00100 > 0].sum()
-
-            # taxable income
-            taxinc = (calc.records.c04800 * calc.records.s006).sum()
-
-            # regular tax
-            regular_tax = (calc.records.c05200 * calc.records.s006).sum()
-
-            # AMT income
-            AMTI = (calc.records.c62100 * calc.records.s006).sum()
-
-            # total AMTs
-            AMT = (calc.records.c09600 * calc.records.s006).sum()
-
-            # number of people paying AMT
-            NumAMT1 = calc.records.s006[calc.records.c09600 > 0].sum()
-
-            # tax before credits
-            tax_bf_credits = (calc.records.c05800 * calc.records.s006).sum()
-
-            # tax before nonrefundable credits 09200
-            tax_bf_nonrefundable = (calc.records.c09200 *
-                                    calc.records.s006).sum()
-
-            # refundable credits
-            refundable = (calc.records._refund * calc.records.s006).sum()
-
-            # nonrefuncable credits
-            nonrefundable = (calc.records.c07100 * calc.records.s006).sum()
-
-            # ospc_tax
-            tax_diff = np.where(calc.records._ospctax -
-                                base_calc.records._ospctax > 0,
-                                calc.records._ospctax -
-                                base_calc.records._ospctax,
-                                0)
-            cap = calc.params.ID_DeductionBenefit_crt * calc.records.c00100
-
-            if calc.params.ID_DeductionBenefit_crt != 0:
-                calc.records._ospctax = np.where(tax_diff < cap,
-                                                 tax_diff +
-                                                 calc.records._ospctax,
-                                                 cap + calc.records._ospctax)
-
-            revenue1 = (calc.records._ospctax * calc.records.s006).sum()
-
-            table.append([returns / math.pow(10, 6), agi / math.pow(10, 9),
-                          NumItemizer1 / math.pow(10, 6), ID / math.pow(10, 9),
-                          NumSTD / math.pow(10, 6), STD / math.pow(10, 9),
-                          PE / math.pow(10, 9), taxinc / math.pow(10, 9),
-                          regular_tax / math.pow(10, 9),
-                          AMTI / math.pow(10, 9), AMT / math.pow(10, 9),
-                          NumAMT1 / math.pow(10, 6),
-                          tax_bf_credits / math.pow(10, 9),
-                          refundable / math.pow(10, 9),
-                          nonrefundable / math.pow(10, 9),
-                          revenue1 / math.pow(10, 9)])
-            calc.increment_year()
-            base_calc.increment_year()
 
         df = DataFrame(table, row_years,
                        ["Returns (#m)", "AGI ($b)", "Itemizers (#m)",

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1744,5 +1744,5 @@ def BenefitSurtax(calc):
         calc.records._surtax = np.where(tax_diff < surtax_cap,
                                         tax_diff,
                                         surtax_cap)
-        
+
         calc.records._ospctax += calc.records._surtax

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -168,9 +168,11 @@ def AGI(_ymod1, c02500, c02700, e02615, c02900, e00100, e02500, XTOT,
 def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900,
             e20500, e20400, e19200, e20550, e20600, e20950, e19500, e19570,
             e19400, e19550, e19800, e20100, e20200, e20900, e21000, e21010,
-            MARS, _sep, c00100, ID_ps, ID_Medical_frt, ID_Casualty_frt,
-            ID_Miscellaneous_frt, ID_Charity_crt_Cash, ID_Charity_crt_Asset,
-            ID_prt, ID_crt, ID_StateLocalTax_HC, ID_Charity_frt, puf):
+            MARS, _sep, c00100, ID_ps, ID_Medical_frt, ID_Medical_HC,
+            ID_Casualty_frt, ID_Casualty_HC, ID_Miscellaneous_frt,
+            ID_Miscellaneous_HC, ID_Charity_crt_Cash, ID_Charity_crt_Asset,
+            ID_prt, ID_crt, ID_StateLocalTax_HC, ID_Charity_frt,
+            ID_Charity_HC, ID_Mortgage_HC, puf):
 
     """
     Itemized Deduction; Form 1040, Schedule A
@@ -253,7 +255,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900,
     # Other Taxes (including state and local)
     c18300 = _statax + e18500 + e18800 + e18900
 
-    # Casulty
+    # Casualty
     if e20500 > 0:
         c37703 = e20500 + ID_Casualty_frt * _posagi
         c20500 = c37703 - ID_Casualty_frt * _posagi
@@ -289,14 +291,14 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900,
 
     # Gross Itemized Deductions
 
-    c21060 = (e20900 + c17000 + (1 - ID_StateLocalTax_HC) * c18300 + c19200 +
-              c19700 + c20500 + c20800 + e21000 + e21010)
+    c21060 = (e20900 + (1- ID_Medical_HC) * c17000 +
+             (1 - ID_StateLocalTax_HC) * c18300 + (1 - ID_Mortgage_HC) * c19200 +
+             (1 - ID_Casualty_HC) * c19700 + (1 - ID_Casualty_HC) * c20500 +
+             (1 - ID_Miscellaneous_HC) * c20800 + e21000 + e21010)
 
     # Limitations on deductions excluding medical, charity etc
     _phase2_i = ID_ps[MARS - 1]
-
     _nonlimited = c17000 + c20500 + e19570 + e21010 + e20900
-    _phase2_i = ID_ps[MARS - 1]
     _limitratio = _phase2_i / _sep
 
     if c21060 > _nonlimited and c00100 > _limitratio:

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1713,23 +1713,23 @@ def ExpandIncome(FICA_ss_trt, SS_Earnings_c, e00200, FICA_mc_trt, e02400,
     return (_expanded_income)
 
 
-def BenefitCap(calc):
-    if calc.params.ID_DeductionBenefit_crt != 1:
+def BenefitSurtax(calc):
+    if calc.params.ID_BenefitSurtax_trt != 1:
         nobenefits_calc = copy.deepcopy(calc)
 
         # hard code the reform
         nobenefits_calc.params.ID_Medical_HC = \
-            int(nobenefits_calc.params.ID_BenefitCap_Switch[0])
+            int(nobenefits_calc.params.ID_BenefitSurtax_Switch[0])
         nobenefits_calc.params.ID_StateLocalTax_HC = \
-            int(nobenefits_calc.params.ID_BenefitCap_Switch[1])
+            int(nobenefits_calc.params.ID_BenefitSurtax_Switch[1])
         nobenefits_calc.params.ID_casualty_HC = \
-            int(nobenefits_calc.params.ID_BenefitCap_Switch[2])
+            int(nobenefits_calc.params.ID_BenefitSurtax_Switch[2])
         nobenefits_calc.params.ID_Miscellaneous_HC = \
-            int(nobenefits_calc.params.ID_BenefitCap_Switch[3])
+            int(nobenefits_calc.params.ID_BenefitSurtax_Switch[3])
         nobenefits_calc.params.ID_Mortgage_HC = \
-            int(nobenefits_calc.params.ID_BenefitCap_Switch[4])
+            int(nobenefits_calc.params.ID_BenefitSurtax_Switch[4])
         nobenefits_calc.params.ID_Charity_HC = \
-            int(nobenefits_calc.params.ID_BenefitCap_Switch[5])
+            int(nobenefits_calc.params.ID_BenefitSurtax_Switch[5])
 
         nobenefits_calc.calc_one_year()
 
@@ -1738,9 +1738,11 @@ def BenefitCap(calc):
                             nobenefits_calc.records._ospctax -
                             calc.records._ospctax, 0)
 
-        cap = nobenefits_calc.params.ID_DeductionBenefit_crt *\
+        surtax_cap = nobenefits_calc.params.ID_BenefitSurtax_trt *\
             nobenefits_calc.records.c00100
 
-        calc.records._ospctax = np.where(tax_diff < cap,
-                                         tax_diff + calc.records._ospctax,
-                                         cap + calc.records._ospctax)
+        calc.records._surtax = np.where(tax_diff < surtax_cap,
+                                        tax_diff,
+                                        surtax_cap)
+        
+        calc.records._ospctax += calc.records._surtax

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -291,10 +291,13 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900,
 
     # Gross Itemized Deductions
 
-    c21060 = (e20900 + (1- ID_Medical_HC) * c17000 +
-             (1 - ID_StateLocalTax_HC) * c18300 + (1 - ID_Mortgage_HC) * c19200 +
-             (1 - ID_Casualty_HC) * c19700 + (1 - ID_Casualty_HC) * c20500 +
-             (1 - ID_Miscellaneous_HC) * c20800 + e21000 + e21010)
+    c21060 = (e20900 + (1 - ID_Medical_HC) * c17000 +
+              (1 - ID_StateLocalTax_HC) * c18300 +
+              (1 - ID_Mortgage_HC) * c19200 +
+              (1 - ID_Casualty_HC) * c19700 +
+              (1 - ID_Casualty_HC) * c20500 +
+              (1 - ID_Miscellaneous_HC) * c20800 +
+              e21000 + e21010)
 
     # Limitations on deductions excluding medical, charity etc
     _phase2_i = ID_ps[MARS - 1]

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1719,18 +1719,19 @@ def BenefitCap(calc):
 
         # hard code the reform
         nobenefits_calc.params.ID_Medical_HC = \
-            nobenefits_calc.params.ID_BenefitCap_Switch[0]
+            int(nobenefits_calc.params.ID_BenefitCap_Switch[0])
         nobenefits_calc.params.ID_StateLocalTax_HC = \
-            nobenefits_calc.params.ID_BenefitCap_Switch[1]
+            int(nobenefits_calc.params.ID_BenefitCap_Switch[1])
         nobenefits_calc.params.ID_casualty_HC = \
-            nobenefits_calc.params.ID_BenefitCap_Switch[2]
+            int(nobenefits_calc.params.ID_BenefitCap_Switch[2])
         nobenefits_calc.params.ID_Miscellaneous_HC = \
-            nobenefits_calc.params.ID_BenefitCap_Switch[3]
+            int(nobenefits_calc.params.ID_BenefitCap_Switch[3])
         nobenefits_calc.params.ID_Mortgage_HC = \
-            nobenefits_calc.params.ID_BenefitCap_Switch[4]
+            int(nobenefits_calc.params.ID_BenefitCap_Switch[4])
         nobenefits_calc.params.ID_Charity_HC = \
-            nobenefits_calc.params.ID_BenefitCap_Switch[5]
+            int(nobenefits_calc.params.ID_BenefitCap_Switch[5])
 
+        print(nobenefits_calc.params._ID_DeductionBenefit_crt)
         nobenefits_calc.calc_one_year()
 
         tax_diff = np.where(nobenefits_calc.records._ospctax -
@@ -1738,7 +1739,7 @@ def BenefitCap(calc):
                             nobenefits_calc.records._ospctax -
                             calc.records._ospctax, 0)
 
-        cap = nobenefits_calc.params.ID_DeductionBenefit_crt * \
+        cap = nobenefits_calc.params.ID_DeductionBenefit_crt *\
             nobenefits_calc.records.c00100
 
         calc.records._ospctax = np.where(tax_diff < cap,

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1714,7 +1714,7 @@ def ExpandIncome(FICA_ss_trt, SS_Earnings_c, e00200, FICA_mc_trt, e02400,
 
 
 def BenefitSurtax(calc):
-    if calc.params.ID_BenefitSurtax_trt != 1:
+    if calc.params.ID_BenefitSurtax_crt != 1:
         nobenefits_calc = copy.deepcopy(calc)
 
         # hard code the reform
@@ -1738,11 +1738,11 @@ def BenefitSurtax(calc):
                             nobenefits_calc.records._ospctax -
                             calc.records._ospctax, 0)
 
-        surtax_cap = nobenefits_calc.params.ID_BenefitSurtax_trt *\
+        surtax_cap = nobenefits_calc.params.ID_BenefitSurtax_crt *\
             nobenefits_calc.records.c00100
 
         calc.records._surtax = np.where(tax_diff > surtax_cap,
                                         tax_diff - surtax_cap,
-                                        0)
+                                        0) * calc.params.ID_BenefitSurtax_trt
 
         calc.records._ospctax += calc.records._surtax

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1731,7 +1731,6 @@ def BenefitCap(calc):
         nobenefits_calc.params.ID_Charity_HC = \
             int(nobenefits_calc.params.ID_BenefitCap_Switch[5])
 
-        print(nobenefits_calc.params._ID_DeductionBenefit_crt)
         nobenefits_calc.calc_one_year()
 
         tax_diff = np.where(nobenefits_calc.records._ospctax -

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -173,7 +173,7 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900,
             ID_Casualty_frt, ID_Casualty_HC, ID_Miscellaneous_frt,
             ID_Miscellaneous_HC, ID_Charity_crt_Cash, ID_Charity_crt_Asset,
             ID_prt, ID_crt, ID_StateLocalTax_HC, ID_Charity_frt,
-            ID_Charity_HC, ID_Mortgage_HC, puf):
+            ID_Charity_HC, ID_InterestPaid_HC, puf):
 
     """
     Itemized Deduction; Form 1040, Schedule A
@@ -294,15 +294,17 @@ def ItemDed(_posagi, e17500, e18400, e18500, e18800, e18900,
 
     c21060 = (e20900 + (1 - ID_Medical_HC) * c17000 +
               (1 - ID_StateLocalTax_HC) * c18300 +
-              (1 - ID_Mortgage_HC) * c19200 +
-              (1 - ID_Casualty_HC) * c19700 +
+              (1 - ID_InterestPaid_HC) * c19200 +
+              (1 - ID_Charity_HC) * c19700 +
               (1 - ID_Casualty_HC) * c20500 +
               (1 - ID_Miscellaneous_HC) * c20800 +
               e21000 + e21010)
 
     # Limitations on deductions excluding medical, charity etc
     _phase2_i = ID_ps[MARS - 1]
-    _nonlimited = c17000 + c20500 + e19570 + e21010 + e20900
+    _nonlimited = ((1 - ID_Medical_HC) * c17000 +
+                   (1 - ID_Casualty_HC) * c20500 +
+                   e19570 + e21010 + e20900)
     _limitratio = _phase2_i / _sep
 
     if c21060 > _nonlimited and c00100 > _limitratio:
@@ -822,15 +824,16 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517,
          c24520, c04800, e10105, c05700, e05800, e05100, e09600,
          KT_c_Age, x62740, e62900, AMT_thd_MarriedS, _earned, e62600,
          AMT_em, AMT_prt, AMT_trt1, AMT_trt2, _cmbtp_itemizer,
-         _cmbtp_standard, ID_StateLocalTax_HC, puf):
+         _cmbtp_standard, ID_StateLocalTax_HC, ID_Medical_HC,
+         ID_Miscellaneous_HC, puf):
 
     c62720 = c24517 + x62720
     c60260 = e00700 + x60260
     # QUESTION: c63100 variable is reassigned below before use, is this a BUG?
     c63100 = max(0., _taxbc - e07300)
-    c60200 = min(c17000, 0.025 * _posagi)
+    c60200 = min((1 - ID_Medical_HC) * c17000, 0.025 * _posagi)
     c60240 = (1 - ID_StateLocalTax_HC) * c18300 + x60240
-    c60220 = c20800 + x60220
+    c60220 = (1 - ID_Miscellaneous_HC) * c20800 + x60220
     c60130 = c21040 + x60130
     c62730 = e24515 + x62730
 
@@ -865,9 +868,10 @@ def AMTI(c60000, _exact, e60290, _posagi, e07300, x60260, c24517,
         _cmbtp = 0.
 
     if (puf and ((_standard == 0 or (_exact == 1 and e04470 > 0)))):
-        c62100 = (c00100 - c04470 + min(c17000, 0.025 * max(0., c00100)) +
-                  (1 - ID_StateLocalTax_HC) * max(0, e18400) +
-                  e18500 - c60260 + c20800 - c21040)
+        c62100 = (c00100 - c04470 + min((1 - ID_Medical_HC) * c17000,
+                  0.025 * max(0., c00100)) +
+                  (1 - ID_StateLocalTax_HC) * max(0, e18400) + e18500 -
+                  c60260 + (1 - ID_Miscellaneous_HC) * c20800 - c21040)
         c62100 += _cmbtp
 
     if (puf and ((_standard > 0 and f6251 == 1))):
@@ -1726,7 +1730,7 @@ def BenefitSurtax(calc):
             int(nobenefits_calc.params.ID_BenefitSurtax_Switch[2])
         nobenefits_calc.params.ID_Miscellaneous_HC = \
             int(nobenefits_calc.params.ID_BenefitSurtax_Switch[3])
-        nobenefits_calc.params.ID_Mortgage_HC = \
+        nobenefits_calc.params.ID_InterestPaid_HC = \
             int(nobenefits_calc.params.ID_BenefitSurtax_Switch[4])
         nobenefits_calc.params.ID_Charity_HC = \
             int(nobenefits_calc.params.ID_BenefitSurtax_Switch[5])

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -6,6 +6,7 @@ import numpy as np
 from .decorators import *
 import copy
 
+
 @iterate_jit(nopython=True)
 def FilingStatus(MARS):
     if MARS == 3 or MARS == 6:
@@ -1713,22 +1714,33 @@ def ExpandIncome(FICA_ss_trt, SS_Earnings_c, e00200, FICA_mc_trt, e02400,
 
 
 def BenefitCap(calc):
-    if calc.params.ID_DeductionBenefit_crt != 0:
+    if calc.params.ID_DeductionBenefit_crt != 1:
         nobenefits_calc = copy.deepcopy(calc)
-        
+
         # hard code the reform
-        nobenefits_calc.params.ID_Medical_HC = nobenefits_calc.params.ID_BenefitCap_Switch[0]
-        nobenefits_calc.params.ID_StateLocalTax_HC = nobenefits_calc.params.ID_BenefitCap_Switch[1]
-        nobenefits_calc.params.ID_casualty_HC = nobenefits_calc.params.ID_BenefitCap_Switch[2]
-        nobenefits_calc.params.ID_Miscellaneous_HC = nobenefits_calc.params.ID_BenefitCap_Switch[3]
-        nobenefits_calc.params.ID_Mortgage_HC = nobenefits_calc.params.ID_BenefitCap_Switch[4]
-        nobenefits_calc.params.ID_Charity_HC = nobenefits_calc.params.ID_BenefitCap_Switch[5]
-        
+        nobenefits_calc.params.ID_Medical_HC = \
+            nobenefits_calc.params.ID_BenefitCap_Switch[0]
+        nobenefits_calc.params.ID_StateLocalTax_HC = \
+            nobenefits_calc.params.ID_BenefitCap_Switch[1]
+        nobenefits_calc.params.ID_casualty_HC = \
+            nobenefits_calc.params.ID_BenefitCap_Switch[2]
+        nobenefits_calc.params.ID_Miscellaneous_HC = \
+            nobenefits_calc.params.ID_BenefitCap_Switch[3]
+        nobenefits_calc.params.ID_Mortgage_HC = \
+            nobenefits_calc.params.ID_BenefitCap_Switch[4]
+        nobenefits_calc.params.ID_Charity_HC = \
+            nobenefits_calc.params.ID_BenefitCap_Switch[5]
+
         nobenefits_calc.calc_one_year()
-        
-        tax_diff = np.where(nobenefits_calc.records._ospctax - calc.records._ospctax > 0, 
-                            nobenefits_calc.records._ospctax - calc.records._ospctax, 0)
-        cap = nobenefits_calc.params.ID_DeductionBenefit_crt * nobenefits_calc.records.c00100
-        calc.records._ospctax =  np.where(tax_diff < cap, 
-                                          tax_diff + calc.records._ospctax, 
-                                          cap + calc.records._ospctax)
+
+        tax_diff = np.where(nobenefits_calc.records._ospctax -
+                            calc.records._ospctax > 0,
+                            nobenefits_calc.records._ospctax -
+                            calc.records._ospctax, 0)
+
+        cap = nobenefits_calc.params.ID_DeductionBenefit_crt * \
+            nobenefits_calc.records.c00100
+
+        calc.records._ospctax = np.where(tax_diff < cap,
+                                         tax_diff + calc.records._ospctax,
+                                         cap + calc.records._ospctax)

--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1741,8 +1741,8 @@ def BenefitSurtax(calc):
         surtax_cap = nobenefits_calc.params.ID_BenefitSurtax_trt *\
             nobenefits_calc.records.c00100
 
-        calc.records._surtax = np.where(tax_diff < surtax_cap,
-                                        tax_diff,
-                                        surtax_cap)
+        calc.records._surtax = np.where(tax_diff > surtax_cap,
+                                        tax_diff - surtax_cap,
+                                        0)
 
         calc.records._ospctax += calc.records._surtax

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -404,7 +404,7 @@
         "row_label": ["2013"],
         "cpi_inflated": true,
         "col_label": ["Medical", "StateLocal", "Casualty", "Miscellaneous", "Interest", "Charity"],        
-        "value":    [[1, 	   1,             1,             1,             1,         1]]
+        "value":    [[true, 	   true,           true,          true,           true,      true]]
     },
      "_EITC_rt":{
         "long_name": "Earned income credit rate",
@@ -1019,7 +1019,7 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value":     [1] 
+        "value":     [1.0] 
     },
     "_NIIT_trt":{
         "long_name": "Net Investment Income Tax rate (UIMC)",

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -404,7 +404,7 @@
         "row_label": ["2013"],
         "cpi_inflated": true,
         "col_label": ["Medical", "StateLocal", "Casualty", "Miscellaneous", "Interest", "Charity"],        
-        "value":    [[1, 	   0,             1,             1,             1,       0]]
+        "value":    [[1, 	   1,             1,             1,             1,         1]]
     },
      "_EITC_rt":{
         "long_name": "Earned income credit rate",
@@ -1019,7 +1019,7 @@
         "row_label": ["2013"],
         "cpi_inflated": false,
         "col_label": "",
-        "value":     [0.0] 
+        "value":     [1] 
     },
     "_NIIT_trt":{
         "long_name": "Net Investment Income Tax rate (UIMC)",

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -1009,8 +1009,8 @@
         "value":     [0.0] 
     },
     "_ID_BenefitSurtax_crt":{
-        "long_name": "Deduction tax benefit surtax cap rate, ceiling as a percent of AGI",
-	"description": "This percentage is used to cap the tax benefit from deductions. Users can specify what deductions they want to apply to. ",
+        "long_name": "Credit on itemized deduction benefit surtax (percent of AGI)",
+	"description": "The surtax on specified itemized deductions applies to benefits in excess of this percent of AGI. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,
@@ -1022,8 +1022,8 @@
         "value":     [1.0] 
     },
     "_ID_BenefitSurtax_trt":{
-        "long_name": "Deduction tax benefit surtax rate",
-	"description": " ",
+        "long_name": "Surtax rate on the benefits from specified itemized deductions",
+	"description": "The benefit from specified itemized deductions exceeding the credit is taxed at this rate. A surtax rate of 1 strictly limits the benefit from specified itemized deductions to the specified credit. In http://www.nber.org/papers/w16921, Feldstein, Feenberg, and MacGuineas propose a credit of 2% of AGI against a 100% tax rate; in their proposal, however, a broader set of tax benefits, including the employer provided health exclusion, would be taxed.",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -995,6 +995,19 @@
         "col_label": "",
         "value":     [0.0] 
     },
+    "_ID_DeductionBenefit_crt":{
+        "long_name": "Deduction tax benefit cap, ceiling as a percent of AGI",
+	"description": "This percentage is used to cap the tax benefit from deductions. Users can specify what deductions they want to apply to. ",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [0.0] 
+    },
     "_NIIT_trt":{
         "long_name": "Net Investment Income Tax rate (UIMC)",
 	"description": "Also called the Unearned Income Medicare Contribution. The lessor of net investment income and the amount by which MAGI exceeds a threshold is taxed at this rate.",

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -813,6 +813,19 @@
         "value":     [0.1] 
 
     },
+     "_ID_Medical_HC":{
+        "long_name": "Medical expense deduction haircut",
+	"description": "This percentage can be applied to limit the amount of medical expense deduction allowed.",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [0.0] 
+    },
      "_ID_Charity_frt":{
         "long_name": "Deduction for charitable contributions; floor as a percent of AGI",
         "description": "Taxpayers are eligible to deduct the portion of their charitable expense exceeding this percentage of AGI.",
@@ -827,6 +840,19 @@
         "value":     [0.0]        
             
     },
+    "_ID_Charity_HC":{
+        "long_name": "Charity expense deduction haircut",
+	"description": "This percentage can be applied to limit the amount of charity expense deduction allowed.",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [0.0] 
+    },
      "_ID_Casualty_frt":{
         "long_name": "Deduction for casualty loss; floor as a percent of AGI",
 	"description": "Taxpayers are eligible to deduct the portion of their casualty loss exceeding this percentage of AGI.",
@@ -840,6 +866,19 @@
         "col_label": "",
         "value":     [0.1]        
     },
+    "_ID_Casualty_HC":{
+        "long_name": "Casualty expense deduction haircut",
+	"description": "This percentage can be applied to limit the amount of casualty expense deduction allowed.",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [0.0] 
+    },
      "_ID_Miscellaneous_frt":{
         "long_name": "Deduction for miscellaneous expenses; floor as a percent of AGI",
 	"description": "Taxpayers are eligible to deduct the portion of their miscellaneous expense exceeding this percentage of AGI.",
@@ -852,6 +891,19 @@
         "cpi_inflated": false,
         "col_label": "",
         "value":     [0.02]        
+    },
+     "_ID_Miscellaneous_HC":{
+        "long_name": "Miscellaneous expense deduction haircut",
+	"description": "This percentage can be applied to limit the amount of miscellaneous expense deduction allowed.",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [0.0] 
     },
      "_ID_Charity_crt_Cash":{
         "long_name": "Deduction for charitable cash contributions; ceiling as a percent of AGI",
@@ -894,7 +946,7 @@
     },
     "_ID_crt":{
         "long_name": "Itemized deduction maximum phaseout as a percent of total itemized deductions (Pease)",
-	    "description": "The phaseout amount is capped at this percentage of the original total deduction. ",
+	"description": "The phaseout amount is capped at this percentage of the original total deduction. ",
         "irs_ref": "Form 1040 Schedule A, line 29, instructions. ",
         "notes": "The ceiling rate cannot be increased above 0.8 due to limited data on non-itemizers.",
         "start_year": 2013,
@@ -917,6 +969,19 @@
         "cpi_inflated": false,
         "col_label": "",
         "value": [0]
+    },
+     "_ID_Mortgage_HC":{
+        "long_name": "Mortgage interest deduction haircut",
+	"description": "This percentage can be applied to limit the amount of mortgage interest deduction allowed.",
+        "irs_ref": "",
+        "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [0.0] 
     },
     "_NIIT_trt":{
         "long_name": "Net Investment Income Tax rate (UIMC)",

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -393,8 +393,8 @@
                     [254200, 	305050,   152525,     279650, 		  305050,  152525],
                     [258250, 	309900,   154950,     284050, 		  309900,  154950]]
     },
-    "_ID_BenefitCap_Switch":{
-        "long_name": "Switch for manipulating itemized deduction benefit cap",
+    "_ID_BenefitSurtax_Switch":{
+        "long_name": "Switch for manipulating itemized deduction benefit surtax",
 	"description": "This parameter is specified by items and year. ",
         "irs_ref": "",
         "notes": "",
@@ -1008,8 +1008,8 @@
         "col_label": "",
         "value":     [0.0] 
     },
-    "_ID_DeductionBenefit_crt":{
-        "long_name": "Deduction tax benefit cap, ceiling as a percent of AGI",
+    "_ID_BenefitSurtax_trt":{
+        "long_name": "Deduction tax benefit surtax rate, ceiling as a percent of AGI",
 	"description": "This percentage is used to cap the tax benefit from deductions. Users can specify what deductions they want to apply to. ",
         "irs_ref": "",
         "notes": "",

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -1008,8 +1008,8 @@
         "col_label": "",
         "value":     [0.0] 
     },
-    "_ID_BenefitSurtax_trt":{
-        "long_name": "Deduction tax benefit surtax rate, ceiling as a percent of AGI",
+    "_ID_BenefitSurtax_cap":{
+        "long_name": "Deduction tax benefit surtax cap rate, ceiling as a percent of AGI",
 	"description": "This percentage is used to cap the tax benefit from deductions. Users can specify what deductions they want to apply to. ",
         "irs_ref": "",
         "notes": "",

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -995,9 +995,9 @@
         "col_label": "",
         "value": [0]
     },
-     "_ID_Mortgage_HC":{
-        "long_name": "Mortgage interest deduction haircut",
-	"description": "This percentage can be applied to limit the amount of mortgage interest deduction allowed.",
+     "_ID_InterestPaid_HC":{
+        "long_name": "Interest deduction haircut",
+	"description": "This percentage can be applied to limit the amount of interest deduction allowed.",
         "irs_ref": "",
         "notes": "This parameter is currently used to eliminate this part of itemized deduction. ",
         "start_year": 2013,

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -1008,9 +1008,22 @@
         "col_label": "",
         "value":     [0.0] 
     },
-    "_ID_BenefitSurtax_cap":{
+    "_ID_BenefitSurtax_crt":{
         "long_name": "Deduction tax benefit surtax cap rate, ceiling as a percent of AGI",
 	"description": "This percentage is used to cap the tax benefit from deductions. Users can specify what deductions they want to apply to. ",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "",
+        "row_var": "",
+        "row_label": ["2013"],
+        "cpi_inflated": false,
+        "col_label": "",
+        "value":     [1.0] 
+    },
+    "_ID_BenefitSurtax_trt":{
+        "long_name": "Deduction tax benefit surtax rate",
+	"description": " ",
         "irs_ref": "",
         "notes": "",
         "start_year": 2013,

--- a/taxcalc/params.json
+++ b/taxcalc/params.json
@@ -393,6 +393,19 @@
                     [254200, 	305050,   152525,     279650, 		  305050,  152525],
                     [258250, 	309900,   154950,     284050, 		  309900,  154950]]
     },
+    "_ID_BenefitCap_Switch":{
+        "long_name": "Switch for manipulating itemized deduction benefit cap",
+	"description": "This parameter is specified by items and year. ",
+        "irs_ref": "",
+        "notes": "",
+        "start_year": 2013,
+        "col_var": "MARS",
+        "row_var": "FLPDYR",
+        "row_label": ["2013"],
+        "cpi_inflated": true,
+        "col_label": ["Medical", "StateLocal", "Casualty", "Miscellaneous", "Interest", "Charity"],        
+        "value":    [[1, 	   0,             1,             1,             1,       0]]
+    },
      "_EITC_rt":{
         "long_name": "Earned income credit rate",
 	"description": "If one taxpayer's AGI is below AGI phaseout start, he can apply this rate to his earned income to calculate the credit amount eligible. ",

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -663,7 +663,7 @@ class Records(object):
                         'c59720', '_comb', 'c07150', 'c10300', '_ospctax',
                         '_refund', 'c11600', 'e11450', 'e82040', 'e11500',
                         '_amed', '_xlin3', '_xlin6', '_cmbtp_itemizer',
-                        '_cmbtp_standard', '_expanded_income']
+                        '_cmbtp_standard', '_expanded_income', '_surtax']
 
         for name in zeroed_names:
             setattr(self, name, np.zeros((self.dim,)))

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -622,7 +622,6 @@ class Records(object):
                         '_amed', '_xlin3', '_xlin6', '_cmbtp_itemizer',
                         '_cmbtp_standard', '_expanded_income', '_surtax']
 
-
         # create zeroed_names variables
         for name in zeroed_names:
             setattr(self, name, np.zeros((self.dim,)))


### PR DESCRIPTION
In this PR, I added some haircut parameters and an additional table-generator function to calculate and present the results of this specific type of reform. 

@talumbau @MattHJensen Haven't add any tests yet, but need your feedback on whether it's ok to implement it this way and whether we need to make it more generalized or not.

@talumbau This kind of reform is different from other reforms in that this one needs two calculators to generate results. Specifically, one calculator carries the default plan results, and the other calculates results with certain parameters set up in a certain way. Then, get the difference of tax from these two calculators, truncate the difference in a certain way and add the truncated diff to the second one to get the final results.

As you can see, this certain type of reform, involving two calculators, is a bit difficult for our current taxcalc and drop q. What I came up with is to use a parameter as a switch to add functionality to our table generator and drop q. This switch is the cap rate of this reform. If this cap rate is not zero, then we can add the truncated diff. 

To play with this type of reform in notebooks, users can use the `diagnostic_table_special_reform()` to view results. This function takes the default plan calculator as an argument.
<img width="1011" alt="screen shot 2015-09-23 at 5 36 57 pm" src="https://cloud.githubusercontent.com/assets/10549597/10059505/545bc33e-6219-11e5-9c8e-a8b6bcd4a5a6.png">


In drop q, similarly I added a few lines both after initializing calc3 and during the process calculating later year results:
```
    # User specified Plans
    params3 = Parameters(start_year=2013)
    params3.implement_reform(reform)
    # Create a Calculator for the user specified plan
    calc3 = Calculator(params=params3, records=records3)
    calc3.increment_year()
    calc3.increment_year()
    assert calc3.current_year == start_year
    calc3.calc_all()
    
    if calc3.params.ID_DeductionBenefit_crt != 0:
        tax_diff = np.where(calc3.records._ospctax - calc1.records._ospctax > 0,
                            calc3.records._ospctax - calc1.records._ospctax, 0)
        cap = calc3.params.ID_DeductionBenefit_crt * calc3.records.c00100
        calc3.records._ospctax = np.where(tax_diff < cap,
                                         tax_diff + calc3.records._ospctax,
                                         cap + calc3.records._ospctax)
```

Both pure taxcalc and taxcalc with drop q are giving me consistent results under this set up. @MattHJensen The results seem fine to me, but not quite sure how to double check. Could you take a look at it?

Default Plan (calc1):
<img width="524" alt="screen shot 2015-09-23 at 5 40 23 pm" src="https://cloud.githubusercontent.com/assets/10549597/10059573/cfb8176c-6219-11e5-8e64-92eeb436e077.png">

Certain Itemized Deduction eliminated starting in 2015 (calc2):
<img width="522" alt="screen shot 2015-09-23 at 5 41 16 pm" src="https://cloud.githubusercontent.com/assets/10549597/10059603/f5e7e0e8-6219-11e5-92e1-0ed10a90b34f.png">

Added the diff (calc2):
<img width="523" alt="screen shot 2015-09-23 at 5 42 16 pm" src="https://cloud.githubusercontent.com/assets/10549597/10059620/126d5dc4-621a-11e5-97f8-f1515964cd0d.png">

