### PR TITLE
Do Records class imputations only if current_year is 2009

### DIFF
--- a/taxcalc/calculate.py
+++ b/taxcalc/calculate.py
@@ -40,11 +40,12 @@ class Calculator(object):
             msg = 'Must supply tax records as a file path or Records object'
             raise ValueError(msg)
 
-        if sync_years and self._records.current_year == 2009:
+        if sync_years and self._records.current_year == Records.PUF_YEAR:
             print("You loaded data for " +
                   str(self._records.current_year) + '.')
 
-            self.records.extrapolate_09_puf()
+            if self._records.current_year == 2009:
+                self.records.extrapolate_2009_puf()
 
             while self._records.current_year < self._params.current_year:
                 self._records.increment_year()

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -235,7 +235,8 @@ class Records(object):
                  data="puf.csv",
                  blowup_factors=blowup_factors_path,
                  weights=weights_path,
-                 start_year=None):
+                 start_year=None,
+                 **kwargs):
         """
         Records class constructor
         """

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -50,13 +50,15 @@ class Records(object):
     parameters of the constructor, and therefore, imputed variables
     are generated to augment the data and initial-year blowup factors
     are applied to the data. Explicitly setting start_year to some
-    value other than 2009 will cause this variable-imputation and
-    initial-year-blowup logic to be skipped.  There are situations in
+    value other than CURRENT_PUF_YEAR will cause this variable-imputation
+    and initial-year-blowup logic to be skipped.  There are situations in
     which this is exactly what is desired, but more often than not,
     skipping the imputation and blowup logic would be a mistake.  In
     other words, do not explicitly specify start_year in the Records
     class constructor unless you know exactly what you are doing.
     """
+
+    CURRENT_PUF_YEAR = 2009
 
     CUR_PATH = os.path.abspath(os.path.dirname(__file__))
     WEIGHTS_FILENAME = "WEIGHTS.csv"
@@ -279,11 +281,15 @@ class Records(object):
         self._read_data(data)
         self._read_blowup(blowup_factors)
         self._read_weights(weights)
-        if start_year:
+        if start_year is None:
+            self._current_year = self.FLPDYR[0]
+        elif isinstance(start_year, int):
             self._current_year = start_year
         else:
-            self._current_year = self.FLPDYR[0]
-        if self._current_year == 2009:
+            msg = ('Records.constructor start_year is neither None nor '
+                   'an integer')
+            raise ValueError(msg)
+        if self._current_year == Records.CURRENT_PUF_YEAR:
             self._impute_variables()
 
     @property
@@ -626,7 +632,7 @@ class Records(object):
         self.e60100 = self.p60100
         self.e27860 = self.s27860
         # specify SOIYR
-        self.SOIYR = np.repeat(2009, self.dim)
+        self.SOIYR = np.repeat(Records.CURRENT_PUF_YEAR, self.dim)
 
     def _read_weights(self, weights):
         if isinstance(weights, pd.core.frame.DataFrame):

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -249,36 +249,37 @@ class Records(object):
         else:
             self._current_year = self.FLPDYR[0]
 
-        """Imputations"""
-        self._cmbtp_itemizer = None
-        self._cmbtp_standard = self.e62100 - self.e00100 + self.e00700
-        self.mutate_imputations()  # Updates the self._cmbtp_itemizer variable
+        if self._current_year == 2009:
+            """Imputations"""
+            self._cmbtp_itemizer = None
+            self._cmbtp_standard = self.e62100 - self.e00100 + self.e00700
+            self.mutate_imputations()  # Updates the self._cmbtp_itemizer variable
 
-        # Standard deduction amount in 2009
-        std2009 = np.array([5700, 11400, 5700, 8350, 11400, 5700, 950])
-        # Additional standard deduction for aged 2009
-        STD_Aged_2009 = np.array([1400., 1100.])
-        # Compulsory itemizers
-        self._compitem = np.where(np.logical_and(self.FDED == 1,
-                                                 self.e04470 <
-                                                 std2009[self.MARS - 1]), 1, 0)
-        # Number of taxpayers
-        self._txpyers = np.where(np.logical_or(self.MARS == 2,
-                                               np.logical_or(self.MARS == 3,
-                                                             self.MARS == 6)),
-                                 2., 1.)
-        # Number of extra standard deductions for aged
-        self._numextra = np.where(np.logical_and(self.FDED == 2, self.e04470 <
-                                  std2009[self.MARS - 1]),
-                                  np.where(
-                                  np.logical_and(self.MARS != 2,
-                                                 self.MARS != 3),
-                                  (self.e04470 - std2009[self.MARS - 1]) /
-                                  STD_Aged_2009[0],
-                                  (self.e04470 - std2009[self.MARS - 1]) /
-                                  STD_Aged_2009[1]),
-                                  np.where(self.e02400 > 0, self._txpyers, 0))
-        self._puf_year = 2009
+            # Standard deduction amount in 2009
+            std2009 = np.array([5700, 11400, 5700, 8350, 11400, 5700, 950])
+            # Additional standard deduction for aged 2009
+            STD_Aged_2009 = np.array([1400., 1100.])
+            # Compulsory itemizers
+            self._compitem = np.where(np.logical_and(self.FDED == 1,
+                                                     self.e04470 <
+                                                     std2009[self.MARS - 1]), 1, 0)
+            # Number of taxpayers
+            self._txpyers = np.where(np.logical_or(self.MARS == 2,
+                                                   np.logical_or(self.MARS == 3,
+                                                                 self.MARS == 6)),
+                                     2., 1.)
+            # Number of extra standard deductions for aged
+            self._numextra = np.where(np.logical_and(self.FDED == 2, self.e04470 <
+                                                     std2009[self.MARS - 1]),
+                                      np.where(
+                                          np.logical_and(self.MARS != 2,
+                                                         self.MARS != 3),
+                                          (self.e04470 - std2009[self.MARS - 1]) /
+                                          STD_Aged_2009[0],
+                                          (self.e04470 - std2009[self.MARS - 1]) /
+                                          STD_Aged_2009[1]),
+                                      np.where(self.e02400 > 0, self._txpyers, 0))
+            self._puf_year = 2009
 
     @property
     def current_year(self):

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -262,29 +262,30 @@ class Records(object):
         self.s006 = self.WT["WT" + str(self.current_year)] / 100
 
     def extrapolate_09_puf(self):
-        self.BF.AGDPN[self._puf_year] = 1
-        self.BF.ATXPY[self._puf_year] = 1
-        self.BF.AWAGE[self._puf_year] = 1.0053
-        self.BF.ASCHCI[self._puf_year] = 1.0041
-        self.BF.ASCHCL[self._puf_year] = 1.1629
-        self.BF.ASCHF[self._puf_year] = 1
-        self.BF.AINTS[self._puf_year] = 1.0357
-        self.BF.ADIVS[self._puf_year] = 1.0606
-        self.BF.ASCHEI[self._puf_year] = 1.1089
-        self.BF.ASCHEL[self._puf_year] = 1.2953
-        self.BF.ACGNS[self._puf_year] = 1.1781
-        self.BF.ABOOK[self._puf_year] = 1
-        self.BF.ARETS[self._puf_year] = 1.0026
-        self.BF.APOPN[self._puf_year] = 1
-        self.BF.ACPIU[self._puf_year] = 1
-        self.BF.APOPDEP[self._puf_year] = 1
-        self.BF.ASOCSEC[self._puf_year] = 0.9941
-        self.BF.ACPIM[self._puf_year] = 1
-        self.BF.AUCOMP[self._puf_year] = 1.0034
-        self.BF.APOPSNR[self._puf_year] = 1
-        self.BF.AIPD[self._puf_year] = 1
-        self._blowup(self._puf_year)
-        self.s006 = self.WT["WT" + str(self._puf_year)] / 100
+        year = 2009
+        self.BF.AGDPN[year] = 1
+        self.BF.ATXPY[year] = 1
+        self.BF.AWAGE[year] = 1.0053
+        self.BF.ASCHCI[year] = 1.0041
+        self.BF.ASCHCL[year] = 1.1629
+        self.BF.ASCHF[year] = 1
+        self.BF.AINTS[year] = 1.0357
+        self.BF.ADIVS[year] = 1.0606
+        self.BF.ASCHEI[year] = 1.1089
+        self.BF.ASCHEL[year] = 1.2953
+        self.BF.ACGNS[year] = 1.1781
+        self.BF.ABOOK[year] = 1
+        self.BF.ARETS[year] = 1.0026
+        self.BF.APOPN[year] = 1
+        self.BF.ACPIU[year] = 1
+        self.BF.APOPDEP[year] = 1
+        self.BF.ASOCSEC[year] = 0.9941
+        self.BF.ACPIM[year] = 1
+        self.BF.AUCOMP[year] = 1.0034
+        self.BF.APOPSNR[year] = 1
+        self.BF.AIPD[year] = 1
+        self._blowup(year)
+        self.s006 = self.WT["WT" + str(year)] / 100
 
     # --- begin private methods of Records class --- #
 
@@ -681,7 +682,6 @@ class Records(object):
                                       (self.e04470 - std2009[self.MARS - 1]) /
                                       STD_Aged_2009[1]),
                                   np.where(self.e02400 > 0, self._txpyers, 0))
-        self._puf_year = 2009
 
     def _imputed_cmbtp_itemizer(self):
         return imputed_cmbtp_itemizer(self.e17500, self.e00100, self.e18400,

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -12,12 +12,12 @@ from taxcalc import Parameters, Records, Calculator, expand_array
 from taxcalc import create_distribution_table, create_difference_table
 
 
-# use simulated 1991 PUF to emulate private 2009 PUF
+# use 1991 PUF-like data to emulate current PUF, which is private
 TAX_DTA_PATH = os.path.join(CUR_PATH, '../../tax_all1991_puf.gz')
 TAX_DTA = pd.read_csv(TAX_DTA_PATH, compression='gzip')
 # PUF-fix-up: MIdR needs to be type int64 to match PUF
 TAX_DTA['midr'] = TAX_DTA['midr'].astype('int64')
-# specify WEIGHTS appropriate for simulated 1991 PUF
+# specify WEIGHTS appropriate for 1991 data
 WEIGHTS_FILENAME = '../../WEIGHTS_testing.csv'
 WEIGHTS_PATH = os.path.join(CUR_PATH, WEIGHTS_FILENAME)
 WEIGHTS = pd.read_csv(WEIGHTS_PATH)

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -1,44 +1,60 @@
 import os
 import sys
+import numpy as np
+import pandas as pd
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(CUR_PATH, "../../"))
-import numpy as np
-from numpy.testing import assert_array_equal
-import pandas as pd
-import pytest
-import tempfile
-from numba import jit, vectorize, guvectorize
-from taxcalc import *
-from taxcalc.utils import expand_array
+from taxcalc import Records, imputed_cmbtp_itemizer, Parameters, Calculator
 
-tax_dta_path = os.path.join(CUR_PATH, "../../tax_all1991_puf.gz")
+# use 1991 PUF-like data to emulate current PUF, which is private
+TAX_DTA_PATH = os.path.join(CUR_PATH, '../../tax_all1991_puf.gz')
+TAX_DTA = pd.read_csv(TAX_DTA_PATH, compression='gzip')
+# PUF-fix-up: MIdR needs to be type int64 to match PUF
+TAX_DTA['midr'] = TAX_DTA['midr'].astype('int64')
+# specify WEIGHTS appropriate for 1991 data
+WEIGHTS_FILENAME = '../../WEIGHTS_testing.csv'
+WEIGHTS_PATH = os.path.join(CUR_PATH, WEIGHTS_FILENAME)
+WEIGHTS = pd.read_csv(WEIGHTS_PATH)
 
 
-def test_create_records():
-    r = Records(tax_dta_path)
-    assert r
+def test_create_records_with_correct_start_year():
+    recs = Records(data=TAX_DTA, weights=WEIGHTS,
+                   start_year=Records.PUF_YEAR)
+    assert recs
+    assert hasattr(recs, '_compitem') == True
+
+
+def test_create_records_with_wrong_start_year():
+    recs = Records(data=TAX_DTA, weights=WEIGHTS,
+                   start_year=2001)
+    assert recs
+    assert hasattr(recs, '_compitem') == False
+    # absence of imputed recs._compitem variable will raise
+    # an error when Calculator.calc_all() is called, guarding
+    # against accidentally specifying wrong start_year
 
 
 def test_create_records_from_file():
-    r = Records.from_file(tax_dta_path)
-    assert r
+    recs = Records.from_file(TAX_DTA_PATH, weigths=WEIGHTS,
+                             start_year=Records.PUF_YEAR)
+    assert recs
+    assert hasattr(recs, '_compitem') == True
 
 
 def test_blow_up():
-    tax_dta = pd.read_csv(tax_dta_path, compression='gzip')
-    tax_dta.flpdyr += 18  # 1991 + 18 = 2009 to emulate using 2009 PUF
-
-    params1 = Parameters(start_year=2013)
-    records1 = Records(tax_dta)
-    assert records1.current_year == 2009
-    # r.current_year == 2009 implies Calculator ctor will call r.blowup()
-
-    calc1 = Calculator(records=records1, params=params1)
-    assert calc1.current_year == 2013
-
+    tax_dta = pd.read_csv(TAX_DTA_PATH, compression='gzip')
+    extra_years = Records.PUF_YEAR - 1991
+    tax_dta.flpdyr += extra_years
+    parms = Parameters()
+    parms_start_year = parms.current_year
+    recs = Records(data=tax_dta)
+    assert recs.current_year == Records.PUF_YEAR
+    # r.current_year == PUF_YEAR implies Calculator ctor will call r.blowup()
+    calc = Calculator(params=parms, records=recs)
+    assert calc.current_year == parms_start_year
     # have e aliases of p variables been maintained after several blowups?
-    assert calc1.records.e23250.sum() == calc1.records.p23250.sum()
-    assert calc1.records.e22250.sum() == calc1.records.p22250.sum()
+    assert calc.records.e23250.sum() == calc.records.p23250.sum()
+    assert calc.records.e22250.sum() == calc.records.p22250.sum()
 
 
 def test_imputation_of_cmbtp_itemizer():
@@ -51,22 +67,17 @@ def test_imputation_of_cmbtp_itemizer():
     e21040 = np.array([45.9, 3., 45.])
     e18500 = np.array([33.1, 18.2, 39.])
     e20800 = np.array([0.9, 32., 52.1])
-
     cmbtp_itemizer = np.array([85.4, -31.0025, -45.7])
-
     """
     Test case values:
-
-    x = max(0., e17500 - max(0., e00100) * 0.075) = [17., 3.7925, 0]
-    medical_adjustment = min(x, 0.025 * max(0.,e00100)) = [-1.,-.2025,0]
+    x = max(0., e17500 - max(0., e00100) * 0.075) = [17., 3.7925, 0.]
+    medical_adjustment = min(x, 0.025 * max(0.,e00100)) = [-1., -.2025, 0.]
     state_adjustment = max(0, e18400) = [42., 34., 49.]
-
     _cmbtp_itemizer = (e62100 - medical_adjustment + e00700 + e04470 + e21040
                        - z - e00100 - e18500 - e20800)
                     = [68.4, -31.0025 ,-84.7]
     """
-
-    test_itemizer = records.imputed_cmbtp_itemizer(e17500, e00100, e18400,
-                                                   e62100, e00700, e04470,
-                                                   e21040, e18500, e20800)
+    test_itemizer = imputed_cmbtp_itemizer(e17500, e00100, e18400,
+                                           e62100, e00700, e04470,
+                                           e21040, e18500, e20800)
     assert np.allclose(cmbtp_itemizer, test_itemizer)

--- a/taxcalc/tests/test_records.py
+++ b/taxcalc/tests/test_records.py
@@ -41,7 +41,7 @@ def test_blow_up():
     assert calc1.records.e22250.sum() == calc1.records.p22250.sum()
 
 
-def test_imputation():
+def test_imputation_of_cmbtp_itemizer():
     e17500 = np.array([20., 4.4, 5.])
     e00100 = np.array([40., 8.1, 90.1])
     e18400 = np.array([25., 34., 10.])
@@ -66,8 +66,7 @@ def test_imputation():
                     = [68.4, -31.0025 ,-84.7]
     """
 
-    test_itemizer = records.imputation(e17500, e00100, e18400,
-                                       e62100, e00700, e04470,
-                                       e21040, e18500, e20800)
-
-    assert(np.allclose(cmbtp_itemizer, test_itemizer))
+    test_itemizer = records.imputed_cmbtp_itemizer(e17500, e00100, e18400,
+                                                   e62100, e00700, e04470,
+                                                   e21040, e18500, e20800)
+    assert np.allclose(cmbtp_itemizer, test_itemizer)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -16,12 +16,12 @@ from numba import jit, vectorize, guvectorize
 from taxcalc import *
 from csv_to_ascii import ascii_output
 
-# use simulated 1991 PUF to emulate private 2009 PUF
+# use 1991 PUF-like data to emulate current PUF, which is private
 TAX_DTA_PATH = os.path.join(CUR_PATH, '../../tax_all1991_puf.gz')
 TAX_DTA = pd.read_csv(TAX_DTA_PATH, compression='gzip')
 # PUF-fix-up: MIdR needs to be type int64 to match PUF
 TAX_DTA['midr'] = TAX_DTA['midr'].astype('int64')
-# specify WEIGHTS appropriate for simulated 1991 PUF
+# specify WEIGHTS appropriate for 1991 data
 WEIGHTS_FILENAME = '../../WEIGHTS_testing.csv'
 WEIGHTS_PATH = os.path.join(CUR_PATH, WEIGHTS_FILENAME)
 WEIGHTS = pd.read_csv(WEIGHTS_PATH)

--- a/taxcalc/tests/test_utils.py
+++ b/taxcalc/tests/test_utils.py
@@ -2,9 +2,9 @@ import os
 import sys
 import filecmp
 import tempfile
-cur_path = os.path.abspath(os.path.dirname(__file__))
-sys.path.append(os.path.join(cur_path, "../../"))
-sys.path.append(os.path.join(cur_path, "../"))
+CUR_PATH = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(CUR_PATH, "../../"))
+sys.path.append(os.path.join(CUR_PATH, "../"))
 import numpy as np
 import pandas as pd
 import pytest
@@ -16,6 +16,15 @@ from numba import jit, vectorize, guvectorize
 from taxcalc import *
 from csv_to_ascii import ascii_output
 
+# use simulated 1991 PUF to emulate private 2009 PUF
+TAX_DTA_PATH = os.path.join(CUR_PATH, '../../tax_all1991_puf.gz')
+TAX_DTA = pd.read_csv(TAX_DTA_PATH, compression='gzip')
+# PUF-fix-up: MIdR needs to be type int64 to match PUF
+TAX_DTA['midr'] = TAX_DTA['midr'].astype('int64')
+# specify WEIGHTS appropriate for simulated 1991 PUF
+WEIGHTS_FILENAME = '../../WEIGHTS_testing.csv'
+WEIGHTS_PATH = os.path.join(CUR_PATH, WEIGHTS_FILENAME)
+WEIGHTS = pd.read_csv(WEIGHTS_PATH)
 
 data = [[1.0, 2, 'a'],
         [-1.0, 4, 'a'],
@@ -32,10 +41,6 @@ data_float = [[1.0, 2, 'a'],
               [0.0000000001, 3, 'b'],
               [-0.0000000001, 1, 'b'],
               [3.0, 6, 'b']]
-
-irates = {1991: 0.015, 1992: 0.020, 1993: 0.022, 1994: 0.020, 1995: 0.021,
-          1996: 0.022, 1997: 0.023, 1998: 0.024, 1999: 0.024, 2000: 0.024,
-          2001: 0.024, 2002: 0.024}
 
 
 def test_expand_1D_short_array():
@@ -116,20 +121,16 @@ def test_expand_2D_variable_rates():
 
 
 def test_create_tables():
-    # specify filename of simulated 1991 PUF used to emulate a more recent PUF
-    cur_path = os.path.abspath(os.path.dirname(__file__))
-    tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
-
     # create a current-law Parameters object and Calculator object calc1
     params1 = Parameters()
-    records1 = Records(tax_dta_path, start_year=2013)
+    records1 = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
     calc1 = Calculator(params=params1, records=records1)
     calc1.calc_all()
     # create a policy-reform Parameters object and Calculator object calc2
     reform = {2013: {'_II_rt4': [0.56]}}
     params2 = Parameters()
     params2.implement_reform(reform)
-    records2 = Records(tax_dta_path, start_year=2013)
+    records2 = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
     calc2 = Calculator(params=params2, records=records2)
     calc2.calc_all()
     # create various distribution tables
@@ -304,11 +305,9 @@ def test_add_weighted_decile_bins():
 
 
 def test_dist_table_sum_row():
-    cur_path = os.path.abspath(os.path.dirname(__file__))
-    tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
     # Create a default Parameters object
     params1 = Parameters()
-    records1 = Records(tax_dta_path, start_year=2013)
+    records1 = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
     # Create a Calculator
     calc1 = Calculator(params=params1, records=records1)
     calc1.calc_all()
@@ -322,18 +321,16 @@ def test_dist_table_sum_row():
 
 
 def test_diff_table_sum_row():
-    cur_path = os.path.abspath(os.path.dirname(__file__))
-    tax_dta_path = os.path.join(cur_path, "../../tax_all1991_puf.gz")
     # create a current-law Parameters object and Calculator calc1
     params1 = Parameters()
-    records1 = Records(tax_dta_path, start_year=2013)
+    records1 = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
     calc1 = Calculator(params=params1, records=records1)
     calc1.calc_all()
     # create a policy-reform Parameters object and Calculator calc2
     reform = {2013: {'_II_rt4': [0.56]}}
     params2 = Parameters()
     params2.implement_reform(reform)
-    records2 = Records(tax_dta_path, start_year=2013)
+    records2 = Records(data=TAX_DTA, weights=WEIGHTS, start_year=2009)
     calc2 = Calculator(params=params2, records=records2)
     calc2.calc_all()
     # create two difference tables and compare their content


### PR DESCRIPTION
This pull request adds an "if self._current_year == 2009:" statement before the imputation code in the Records class constructor.  This is done because the imputations make no sense if the Records data are for any other year (as is the case, for example, in the new TAXSIM-like capability described in issue #291).  When making this change, the imputation code was put into its own private method to avoid PEP8 warnings about lines being too long.  Also, several other non-substantive code changes were made to make the imputation logic easier to follow or to eliminate pylint warnings.  After all these changes, the test.py script produces exactly the same results (using the 2009 puf.csv as Records data) as test.py did before these changes.

The last three commits were added to revise test code to use the revisions in the records.py file.