### PR TITLE
employer only pays half of fica taxes for expanded_income

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -1694,8 +1694,9 @@ def Taxer_i(inc_in, MARS, II_rt1, II_rt2, II_rt3, II_rt4, II_rt5, II_rt6,
 def ExpandIncome(FICA_ss_trt, SS_Earnings_c, e00200, FICA_mc_trt, e02400,
                  c02500, c00100, e00400):
 
-    employer_share_fica = (max(0, FICA_ss_trt * min(SS_Earnings_c, e00200) +
-                           FICA_mc_trt * e00200))
+    employer_share_fica = (max(0,
+                           0.5 * FICA_ss_trt * min(SS_Earnings_c, e00200) +
+                           0.5 * FICA_mc_trt * e00200))
 
     non_taxable_ss_benefits = (e02400 - c02500)
 


### PR DESCRIPTION
We mean to include the employer share of fica in our expanded income measure (see #222). I noticed that we were including both the employee and employer shares since our tax rates include both and we weren't multiplying by 0.5. This is a fix.  

@martinholmer, could you review this PR and merge if it looks good? 
