### PR TITLE
keep s006 as an an array rather than data series 

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -396,7 +396,7 @@ class Records(object):
         # Implement Stage 1 Extrapolation blowup factors
         self._blowup(self._current_year)
         # Implement Stage 2 Extrapolation reweighting.
-        self.s006 = (self.WT["WT" + str(self.current_year)] / 100).as_matrix()
+        self.s006 = (self.WT["WT" + str(self.current_year)] / 100).values
 
     def extrapolate_2009_puf(self):
         year = 2009

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -396,7 +396,7 @@ class Records(object):
         # Implement Stage 1 Extrapolation blowup factors
         self._blowup(self._current_year)
         # Implement Stage 2 Extrapolation reweighting.
-        self.s006 = self.WT["WT" + str(self.current_year)] / 100
+        self.s006 = (self.WT["WT" + str(self.current_year)] / 100).as_matrix()
 
     def extrapolate_2009_puf(self):
         year = 2009


### PR DESCRIPTION
In increment year we replace s006 with a dataseries from our weights dataframe. This is a quick fix to keep s006 as an array and maintain consistency with the other records attributes. 

cc @martinholmer and @Amy-Xu 