### PR TITLE
fully optimize itemization

### DIFF
--- a/taxcalc/functions.py
+++ b/taxcalc/functions.py
@@ -417,11 +417,8 @@ def AMED(_fica, e00200, MARS, AMED_thd, _sey, AMED_trt,
 
 @iterate_jit(nopython=True, puf=True)
 def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
-           MARS, MIDR, e15360, AGEP, AGES, PBI, SBI, _exact, e04200, e02400,
-           STD_Aged, c04470, c00100, c21060, c21040, e37717, c04600, e04805,
-           t04470, f6251, _feided, c02700, FDED, II_rt1, II_rt2, II_rt3,
-           II_rt4, II_rt5, II_rt6, II_rt7, II_brk1, II_brk2, II_brk3, II_brk4,
-           II_brk5, II_brk6, _txpyers, _numextra, puf):
+           MARS, MIDR, e15360, AGEP, AGES, PBI, SBI, _exact, e04200,
+           STD_Aged, _txpyers, f6251, _numextra, puf):
 
     """
 
@@ -459,22 +456,6 @@ def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
         requirement indicator:
             0 - not necessary to itemize because of filing status
             1 - necessary to itemize when filing separately
-
-        FDED : Form of deduction
-            0 - itemized deductions
-            1 - standard deduction
-            2 - taxpayer did not use itemized or standard deduction
-
-    Intermediate Variable:
-        c00100 : AGI
-
-        c04470 : Itemized deduction amount: set to zero if not itemizer
-
-        c04800 : Taxable Income.
-
-        _taxinc : Taxable income less limited exemptions
-
-
 
 
     Returns
@@ -527,6 +508,17 @@ def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
     if (MARS == 3 or MARS == 6) and (MIDR == 1):
         _standard = 0.
 
+    return _standard, c04200, _numextra, c15200, c15100, x04500, _txpyers
+
+
+@iterate_jit(nopython=True, puf=False)
+def TaxInc(c00100, c04470, c04100, _standard, e37717, c21060, c21040,
+           e04470, c04200, c04500, c04600, x04500,
+           e04805, t04470, f6251, _exact, _feided, c04800, MARS,
+           II_rt1, II_rt2, II_rt3, II_rt4,
+           II_rt5, II_rt6, II_rt7, II_brk1, II_brk2, II_brk3,
+           II_brk4, II_brk5, II_brk6, _numextra, FDED, c02700):
+
     # c04500 = c00100 - max(c04470, max(c04100, _standard + e37717))
     c04500 = c00100 - max(c21060 - c21040, _standard + e37717)
 
@@ -541,11 +533,11 @@ def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
     c04800 = max(0., c04500 - c04600 - e04805)
 
     # Check with Dan whether this is right!
-    if c04470 > _standard:
-        _standard = 0.
+    # if c04470 > _standard:
+    #     _standard = 0.
 
-    if c04470 <= _standard:
-        c04470 = 0.
+    # if c04470 <= _standard:
+    #     c04470 = 0.
 
     # why is this here, c60000 is reset many times?
     if _standard > 0:
@@ -577,8 +569,8 @@ def StdDed(DSI, _earned, STD, e04470, e00100, e60000,
     else:
         _feitax, _oldfei = 0., 0.
 
-    return (c15100, _numextra, _txpyers, c15200, c04470, _othded, c04100,
-            c04200, _standard, c04500, c04800, c60000, _amtstd, _taxinc,
+    return (c04470, _othded, c04100,
+            c04500, c04800, c60000, _amtstd, _taxinc,
             _feitax, _oldfei)
 
 

--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -363,7 +363,7 @@ class Records(object):
                     '_amed', '_xlin3', '_xlin6', '_cmbtp_itemizer',
                     '_cmbtp_standard', '_expanded_income', 'c07300',
                     'c07600', 'c07240', 'c62100_everyone',
-                    '_surtax']
+                    '_surtax', 'x04500']
 
     def __init__(self,
                  data="puf.csv",

--- a/taxcalc/tests/test_calculate.py
+++ b/taxcalc/tests/test_calculate.py
@@ -57,6 +57,7 @@ def run():
     cur_set = set(totaldf.columns)
     exp_set.add('_avail')
     exp_set.add('c62100_everyone')
+    exp_set.add('x04500')
 
     assert(exp_set == cur_set)
 


### PR DESCRIPTION
@martinholmer, I believe this solves the itemization optimization issue you identified. 


There are still some differences with internet taxsim that I am trying to deal with now, but we might want to wait for another PR:

```
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 17   2179      0  76000.00 [86567]
      #big_vardiffs_with_big_inctax_diff=                3
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 18   2179      0 -29050.00 [54361]
      #big_vardiffs_with_big_inctax_diff=                3
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 19   2347    168  -8027.50 [54361]
      #big_vardiffs_with_big_inctax_diff=                3
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 22     46      0   -814.00 [78456]
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 25    109    109      0.01 [15329]
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 26   2317      0 -40000.00 [23353]
      #big_vardiffs_with_big_inctax_diff=                3
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 27    736    715   7937.50 [54361]
      #big_vardiffs_with_big_inctax_diff=                3
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]= 28    158     91  -7937.50 [54361]
      #big_vardiffs_with_big_inctax_diff=                3
TAXDIFF:ovar,#diffs,#1cdiffs,maxdiff[id]=  4    851    848    178.00 [2412]
                       #big_inctax_diffs=                3
```

Here is record 54361

```
input 
54361 2013 0 3 2 0 169600 0 3000 0 0 0 0 0 1900 36100 0 2000 1 0 -3000 -1000

taxsim
54361. 2013 0 34445.00 .00 19017.20 32.50 .00 2.90 171600.00 2000.00 .00 8950.00 11700.00 .00 .00 .00 150950.00 33005.00 .00 .00 .00 .00 .00 .00 171600.00 1830.00 32615.00 19017.20 174601.01 .00 .00 .00 .00 .00 .00 .00 .00 .00 .00 .00

simtax
54361. 2013 0 34445.00 0.00 19017.20 0.00 0.00 0.00 171600.00 2000.00 0.00 0.00 11700.00 0.00 0.00 38000.00 121900.00 24977.50 0.00 0.00 0.00 0.00 0.00 0.00 171600.00 9767.50 24677.50
```
