### PR TITLE
Added blowup for e87521, American Opportunity Credit

### DIFF
--- a/taxcalc/records.py
+++ b/taxcalc/records.py
@@ -618,6 +618,7 @@ class Records(object):
         self.p27895 *= self.BF.ATXPY[year]
         self.e87530 *= self.BF.ATXPY[year]
         self.e87550 *= self.BF.ATXPY[year]
+        self.e87521 *= self.BF.ATXPY[year]
         self.RECID *= 1.
         self.s006 *= 1.
         self.s008 *= 1.


### PR DESCRIPTION
I noticed that we don't have `e87521` blowed-up in records.py and thus added, please review and see if this is a good way to do that. Thanks!
@Amy-Xu 