### PR TITLE
Activate test_3 in tests_simpletaxio.py file

### DIFF
--- a/taxcalc/simpletaxio.py
+++ b/taxcalc/simpletaxio.py
@@ -438,7 +438,7 @@ class SimpleTaxIO(object):
             zero_dict[names[1]] = 0
         dict_list = [zero_dict for _ in range(0, len(self._input))]
         # use dict_list to create a Pandas DataFrame and Records object
-        recsdf = pd.DataFrame(dict_list, dtype='int32')
+        recsdf = pd.DataFrame(dict_list, dtype='int64')
         recs = Records(data=recsdf, start_year=2013)
         assert recs.dim == len(self._input)
         # specify input for each tax filing unit in Records object

--- a/taxcalc/tests/test_simpletaxio.py
+++ b/taxcalc/tests/test_simpletaxio.py
@@ -141,5 +141,5 @@ def test_3(input_file):  # pylint: disable=redefined-outer-name
     """
     reform_file_name = None
     simtax = SimpleTaxIO(input_file.name, reform_file_name)
-    # simtax.calculate(write_output_file=False)  # TODO: active after T-CI fix
+    simtax.calculate(write_output_file=False)
     assert simtax.number_input_lines() == NUM_INPUT_LINES


### PR DESCRIPTION
This test passes on local computer as shown by the following:
```
============================= test session starts =================
platform darwin -- Python 2.7.10 -- py-1.4.27 -- pytest-2.7.1
rootdir: /Users/mrh/work/OSPC/tax-calculator, inifile: setup.cfg
collected 93 items

tests/test_behavior.py ...
tests/test_calculate.py ...............
tests/test_decorators.py .................
tests/test_growth.py .....
tests/test_policy.py ................
tests/test_records.py ......
tests/test_simpletaxio.py ...
tests/test_utils.py ............................

========================== 93 passed in 88.24 seconds =============
```