### PR TITLE
Numba Dependency Updated

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - python
 - numpy <= 1.9.3
 - pandas <=0.16.1
-- numba
+- numba <= 0.19.1
 - toolz
 - six
 - ipython


### PR DESCRIPTION
I ran into such error message when executing the command `simtax.py` after creating one valid input file under legit directory. Switching back to previous version of `numba` resolved the issue. (Note that `llvmlite` package has been also downgraded simultaneously, not sure if this matters)
```
Traceback (most recent call last):
  File "../../simtax.py", line 70, in <module>
    sys.exit(main())
  File "../../simtax.py", line 63, in main
    simtax.calculate(no_marginal_tax_rates=args.nomtr)
  File "/Users/Sean.Wang/Documents/OSPC/tax-calculator/taxcalc/simpletaxio.py", line 85, in calculate
    self._calc.calc_all()
  File "/Users/Sean.Wang/Documents/OSPC/tax-calculator/taxcalc/calculate.py", line 154, in calc_all
    self.calc_one_year()
  File "/Users/Sean.Wang/Documents/OSPC/tax-calculator/taxcalc/calculate.py", line 95, in calc_one_year
    AGI(self.policy, self.records)
  File "/Users/Sean.Wang/Documents/OSPC/tax-calculator/taxcalc/decorators.py", line 354, in wrapper
    ans = high_level_fn(*args, **kwargs)
  File "<string>", line 6, in hl_func
  File "//anaconda/lib/python2.7/site-packages/numba/dispatcher.py", line 171, in _compile_for_args
    return self.compile(sig)
  File "//anaconda/lib/python2.7/site-packages/numba/dispatcher.py", line 348, in compile
    flags=flags, locals=self.locals)
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 637, in compile_extra
    return pipeline.compile_extra(func)
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 358, in compile_extra
    return self.compile_bytecode(bc, func_attr=self.func_attr)
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 367, in compile_bytecode
    return self._compile_bytecode()
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 624, in _compile_bytecode
    return pm.run(self.status)
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 250, in run
    raise patched_exception
numba.errors.LoweringError: Caused By:
Traceback (most recent call last):
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 242, in run
    res = stage()
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 580, in stage_nopython_backend
    return self._backend(lowerfn, objectmode=False)
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 533, in _backend
    lowered = lowerfn()
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 524, in backend_nopython_mode
    self.flags)
  File "//anaconda/lib/python2.7/site-packages/numba/compiler.py", line 766, in native_lowering_stage
    lower.lower()
  File "//anaconda/lib/python2.7/site-packages/numba/lowering.py", line 123, in lower
    self.lower_normal_function(self.fndesc)
  File "//anaconda/lib/python2.7/site-packages/numba/lowering.py", line 158, in lower_normal_function
    entry_block_tail = self.lower_function_body()
  File "//anaconda/lib/python2.7/site-packages/numba/lowering.py", line 183, in lower_function_body
    self.lower_block(block)
  File "//anaconda/lib/python2.7/site-packages/numba/lowering.py", line 201, in lower_block
    raise LoweringError(msg, inst.loc)
LoweringError: Internal error:
NotImplementedError: No definition for lowering <class 'numba.types.Dispatcher'>(float64, float64, float64, float64, float64, int32, int32, int32, int64, array(int64, 1d, C), int32, float64, float64, int32) -> (float64, float64, float64, float64, int64, float64, int64, float64)
File "<string>", line 3

Failed at nopython (nopython mode backend)
Internal error:
NotImplementedError: No definition for lowering <class 'numba.types.Dispatcher'>(float64, float64, float64, float64, float64, int32, int32, int32, int64, array(int64, 1d, C), int32, float64, float64, int32) -> (float64, float64, float64, float64, int64, float64, int64, float64)
File "<string>", line 3
```